### PR TITLE
Remove the custom github actions workflow after creating new project

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -96,8 +96,9 @@
             "recipes/{$name}": ["type:drupal-recipe"],
             "docroot/themes/custom/{$name}": ["type:drupal-custom-theme"]
         },
-        "patches": {
-        }
+        "patches": {}
     },
-    "scripts": {}
+    "scripts": {
+        "post-create-project-cmd": "rm -rf .github/"
+    }
 }


### PR DESCRIPTION
**Motivation**
The github actions workflow is used to test this repo - to make sure new projects can be built from it. It's not meant to be a template for testing projects bootstrapped with this.

**Proposed changes**
Remove the workflow after creating a new project via a simple post-create-project-cmd script. See: https://getcomposer.org/doc/articles/scripts.md
