### PR TITLE
Remove patch for trash

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -97,11 +97,7 @@
             "recipes/{$name}": ["type:drupal-recipe"],
             "docroot/themes/custom/{$name}": ["type:drupal-custom-theme"]
         },
-        "patches": {
-            "drupal/trash": {
-                "3493912 - Drupal CMS Installation Fails due to Trash": "https://git.drupalcode.org/project/trash/-/merge_requests/34/diffs.patch"
-            }
-        }
+        "patches": {}
     },
     "scripts": {
         "post-create-project-cmd": "rm -rf .github/"


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
#3493912 was committed to trash, so we no longer need that patch.

**Proposed changes**
Remove the patch from composer.json

**Alternatives considered**
I considered enforcing >= Trash 3.0.19, which is the first release with that issue, but Trash isn't a direct dependency of the scaffold project and I'd rather not add it if possible.
