### PR TITLE
Remove recipe unpacker

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,6 @@
         "drupal/byte": "^1",
         "drupal/config_sync_without_site_uuid": "^1.0@beta",
         "drupal/core-composer-scaffold": "^11.3",
-        "drupal/core-recipe-unpack": "^11.3",
         "drupal/core-recommended": "^11.3",
         "drupal/core-vendor-hardening": "^11.3",
         "drupal/drupal_cms_accessibility_tools": "^2",


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Recipe unpacker is incompatible with ACLI's push:artifact command. The /recipes folder is empty in the artifact.

While not ideal, the lesser of two evils is to not unpack recipe dependencies into the root composer.json file for now while we fix the integration.
