### PR TITLE
Create and rebuild dist branch that's ready for deployment

### DIFF
--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -1,5 +1,4 @@
 name: Build and Deploy Artifact to dist Branch
-
 on:
   push:
     branches:
@@ -9,6 +8,8 @@ on:
     - cron: '0 8 * * *'
     - cron: '0 16 * * *'
   workflow_dispatch:
+env:
+  ARTIFACT_DIR: /tmp/artifact
 
 jobs:
   build-artifact:
@@ -51,16 +52,16 @@ jobs:
 
       - name: Prepare artifact directory
         run: |
-          mkdir -p /tmp/artifact
+          mkdir -p $ARTIFACT_DIR
 
           rsync -av \
             --exclude='.git' \
             --exclude='.github' \
-            ./ /tmp/artifact/
+            ./ $ARTIFACT_DIR
 
       - name: Install Drupal and export configuration
         run: |
-          cd /tmp/artifact
+          cd $ARTIFACT_DIR
 
           # Create files directories and make sure they stick around.
           mkdir -p docroot/sites/default/files
@@ -83,7 +84,7 @@ jobs:
 
       - name: Remove values that should be unique and provide a way to replace them.
         run: |
-          cd /tmp/artifact
+          cd $ARTIFACT_DIR
           
           # Remove the site UUID.
           yq -i '.uuid = ""' "config/default/system.site.yml"
@@ -122,7 +123,7 @@ jobs:
 
       - name: Deploy to dist branch
         run: |
-          cd /tmp/artifact
+          cd $ARTIFACT_DIR
 
           cat >> .gitignore << EOF
           


### PR DESCRIPTION
**Motivation**
We need a prebuilt codebase that can immediately be deployed without any further action. This PR provides a github action that builds an artifact and pushes it to the `dist` branch every time a change is made to the default branch and every 8 hours.

**Proposed changes**
* Add a githib action (`build-artifact.yml`) that builds an artifact on the dist branch
* Removes values that should be unique from the artifact (site UUID and salt)
* Provides a script to repopulate those values.

**Usage**
* Clone this repo
* Checkout the dist branch
* Delete the .git directory
* Optionally, initiate your own git repo
* Run `./scripts/populate-unique.sh`
* Run `./vendor/bin/drush site:install --existing-config --yes`
* Run `./vendor/bin/drush content:import ../recipes/drupal_cms_starter/contyent --yes`

**Alternatives considered**
I thought about using ACLI to generate the artifact, but that seemed heavy handed and ACLI assumes you're pushing to a remote, not a local branch.

**Testing steps**
Same as Usage.
*BUT NOTE:* The dist branch hasn't actually been created in this repo because the workflow hasn't been committed. The `balsama/drupal-cms-project` repo has a built dist branch for testing.

**TODO**
Switch to Drupal CMS's config export command which should strip the config hashes automatically
