### PR TITLE
Remove pulse

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,6 @@
         "drupal/healthcare": "^1.0",
         "drupal/local": "^1.0",
         "drupal/provus_edu": "^1.0",
-        "drupal/pulse": "^1.0",
         "drupal/recipe_installer_kit": "^1.0.4",
         "drupal/webform": "@beta"
     },

--- a/docroot/sites/default/site-templates.php
+++ b/docroot/sites/default/site-templates.php
@@ -71,19 +71,6 @@ return [
     ],
     'creator' => 'Kanopi Studios',
   ],
-  'pulse' => [
-    'name' => 'Pulse',
-    'description' => 'Designed for a modern health and wellness platform. Features sections for health topics, research studies, expert insights, articles, and reviews. Supports FAQs, trending content, and expert consultation forms.',
-    'screenshot' => 'https://git.drupalcode.org/project/pulse/-/raw/1.0.x/screenshot.webp?ref_type=heads',
-    'package' => 'drupal/pulse',
-    'links' => [
-      [
-        'text' => 'Learn more',
-        'url' => 'https://new.drupal.org/site-template/pulse-healthcare',
-      ],
-    ],
-    'creator' => 'QED42',
-  ],
   'local' => [
     'name' => 'Local',
     'description' => 'A local council website with services, navigation, and demo content in a classic blue and white palette.',


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Pulse is currently throwing an error during install.

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Temporarily remove Pulse from this repo and the list of site templates that can be installed from it.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->
Allow the pulse build to fail. But we don't want failing installs in our repo at all.

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->
CI should show that pulse is no longer in the matrix of templates tested. CI should pass.