### PR TITLE
Add acquia_id and acquia_trials_id modules for Acquia ID SSO

### DIFF
--- a/.github/workflows/kernel-tests.yml
+++ b/.github/workflows/kernel-tests.yml
@@ -1,17 +1,31 @@
-name: Unit Tests
+name: Kernel Tests
 on:
   push:
   pull_request:
 
 jobs:
-  unit-tests:
-    name: PHPUnit (PHP ${{ matrix.php-versions }})
+  kernel-tests:
+    name: PHPUnit Kernel (PHP ${{ matrix.php-versions }})
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
         php-versions: ['8.5']
+
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: drupal_test
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping --silent"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=3
 
     steps:
       - name: Checkout
@@ -21,7 +35,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-          extensions: mbstring, xml, ctype, iconv, intl
+          extensions: mbstring, xml, ctype, iconv, intl, pdo_mysql
           coverage: none
 
       - name: Get composer cache directory
@@ -38,6 +52,8 @@ jobs:
       - name: Install Composer dependencies
         run: composer install --no-progress --prefer-dist --optimize-autoloader
 
-      - name: Run custom module unit tests
+      - name: Run custom module kernel tests
         working-directory: docroot/core
-        run: ../../vendor/bin/phpunit --testsuite=unit ../modules/custom/
+        env:
+          SIMPLETEST_DB: mysql://root:root@127.0.0.1:3306/drupal_test
+        run: ../../vendor/bin/phpunit --testsuite=kernel ../modules/custom/

--- a/.github/workflows/kernel-tests.yml
+++ b/.github/workflows/kernel-tests.yml
@@ -56,4 +56,4 @@ jobs:
         working-directory: docroot/core
         env:
           SIMPLETEST_DB: mysql://root:root@127.0.0.1:3306/drupal_test
-        run: ../../vendor/bin/phpunit --testsuite=kernel ../modules/custom/
+        run: ../../vendor/bin/phpunit ../modules/custom/*/tests/src/Kernel

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -40,4 +40,4 @@ jobs:
 
       - name: Run custom module unit tests
         working-directory: docroot/core
-        run: ../../vendor/bin/phpunit --testsuite=unit ../modules/custom/
+        run: ../../vendor/bin/phpunit ../modules/custom/*/tests/src/Unit

--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,4 @@ oauth_keys/
 /.env*
 /.editorconfig
 /.gitattributes
+/.claude

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,8 @@
         "drupal/local": "^1.0",
         "drupal/provus_edu": "^1.0",
         "drupal/recipe_installer_kit": "^1.0.4",
-        "drupal/webform": "@beta"
+        "drupal/webform": "@beta",
+        "league/oauth2-client": "^2"
     },
     "require-dev": {
         "drupal/core-dev": "^11",

--- a/docroot/modules/custom/acquia_id/README.md
+++ b/docroot/modules/custom/acquia_id/README.md
@@ -36,7 +36,7 @@ final class MyAuthorizationSubscriber implements EventSubscriberInterface {
   }
 
   public function onAuthorization(OAuth2AuthorizationEvent $event): void {
-    $resourceOwner = $event->getProvider()->getResourceOwner($event->getAccessToken());
+    $resourceOwner = $event->provider->getResourceOwner($event->accessToken);
     $user = user_load_by_mail($resourceOwner->getId());
     if ($user) {
       $event->setUser($user);

--- a/docroot/modules/custom/acquia_id/README.md
+++ b/docroot/modules/custom/acquia_id/README.md
@@ -1,0 +1,50 @@
+# Acquia ID
+
+Provides OAuth2 single sign-on via Acquia ID (`id.acquia.com`) using the PKCE authorization code flow.
+
+## Configuration
+
+Set the following service parameters, typically in `settings.php` or a `services.yml` override:
+
+```yaml
+parameters:
+  acquia_id.client_id: 'your-oauth2-client-id'
+  acquia_id.idp_base_uri: 'https://id.acquia.com/oauth2/default'
+  acquia_id.cloud_api_base_uri: 'https://cloud.acquia.com'
+  acquia_id.idp_logout_redirect_uri: 'https://cloud.acquia.com'
+```
+
+The SSO route is `/acquia-id/sso`.
+
+## Implementing user resolution
+
+This module dispatches `\Drupal\acquia_id\Events\OAuth2AuthorizationEvent` once the
+OAuth2 token exchange succeeds. **You must provide an event subscriber** that calls
+`$event->setUser($user)` with the resolved Drupal user entity. If no user is set
+after the event is dispatched, the SSO flow redirects to `idp_logout_redirect_uri`.
+
+Example subscriber:
+
+```php
+use Drupal\acquia_id\Events\OAuth2AuthorizationEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+final class MyAuthorizationSubscriber implements EventSubscriberInterface {
+
+  public static function getSubscribedEvents(): array {
+    return [OAuth2AuthorizationEvent::class => 'onAuthorization'];
+  }
+
+  public function onAuthorization(OAuth2AuthorizationEvent $event): void {
+    $resourceOwner = $event->getProvider()->getResourceOwner($event->getAccessToken());
+    $user = user_load_by_mail($resourceOwner->getId());
+    if ($user) {
+      $event->setUser($user);
+    }
+  }
+
+}
+```
+
+Throw `\Drupal\Core\Access\AccessException` from the subscriber to deny login and
+redirect to `idp_logout_redirect_uri`.

--- a/docroot/modules/custom/acquia_id/README.md
+++ b/docroot/modules/custom/acquia_id/README.md
@@ -9,9 +9,9 @@ Set the following service parameters, typically in `settings.php` or a `services
 ```yaml
 parameters:
   acquia_id.client_id: 'your-oauth2-client-id'
-  acquia_id.idp_base_uri: 'https://id.acquia.com/oauth2/default'
-  acquia_id.cloud_api_base_uri: 'https://cloud.acquia.com'
-  acquia_id.idp_logout_redirect_uri: 'https://cloud.acquia.com'
+  # These default to production values and only need overriding for non-production environments.
+  # acquia_id.idp_base_uri: 'https://id.acquia.com/oauth2/default'
+  # acquia_id.cloud_api_base_uri: 'https://cloud.acquia.com'
 ```
 
 The SSO route is `/acquia-id/sso`.

--- a/docroot/modules/custom/acquia_id/acquia_id.info.yml
+++ b/docroot/modules/custom/acquia_id/acquia_id.info.yml
@@ -1,0 +1,7 @@
+name: 'Acquia ID'
+type: module
+description: 'OAuth2 single sign-on via Acquia ID (id.acquia.com).'
+package: Acquia
+core_version_requirement: ^11
+dependencies:
+  - drupal:user

--- a/docroot/modules/custom/acquia_id/acquia_id.module
+++ b/docroot/modules/custom/acquia_id/acquia_id.module
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * @file
+ * Hook implementations for the Acquia ID module.
+ */
+
+declare(strict_types=1);
+
+use Drupal\Core\Session\AccountInterface;
+use Drupal\user\UserInterface;
+
+/**
+ * Implements hook_user_logout().
+ */
+function acquia_id_user_logout(AccountInterface $account): void {
+  \Drupal::service('acquia_id.oauth2.access_token_repository')->delete((int) $account->id());
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_delete() for user entities.
+ */
+function acquia_id_user_delete(UserInterface $account): void {
+  \Drupal::service('acquia_id.oauth2.access_token_repository')->delete((int) $account->id());
+}

--- a/docroot/modules/custom/acquia_id/acquia_id.routing.yml
+++ b/docroot/modules/custom/acquia_id/acquia_id.routing.yml
@@ -1,0 +1,8 @@
+acquia_id.sso:
+  path: '/acquia-id/sso'
+  defaults:
+    _controller: Drupal\acquia_id\Controller\OAuth2Controller
+  requirements:
+    _custom_access: 'Drupal\acquia_id\Controller\OAuth2Controller::access'
+  options:
+    no_cache: TRUE

--- a/docroot/modules/custom/acquia_id/acquia_id.services.yml
+++ b/docroot/modules/custom/acquia_id/acquia_id.services.yml
@@ -1,5 +1,5 @@
 parameters:
-  acquia_id.client_id: ''
+  acquia_id.client_id: '6d45a187-098e-4b20-8205-05f6254bc0f6'
   acquia_id.idp_base_uri: 'https://id.acquia.com/oauth2/default'
   acquia_id.cloud_api_base_uri: 'https://cloud.acquia.com'
   acquia_id.idp_logout_redirect_uri: 'https://cloud.acquia.com'

--- a/docroot/modules/custom/acquia_id/acquia_id.services.yml
+++ b/docroot/modules/custom/acquia_id/acquia_id.services.yml
@@ -1,7 +1,7 @@
 parameters:
   acquia_id.client_id: ''
-  acquia_id.idp_base_uri: ''
-  acquia_id.cloud_api_base_uri: ''
+  acquia_id.idp_base_uri: 'https://id.acquia.com/oauth2/default'
+  acquia_id.cloud_api_base_uri: 'https://cloud.acquia.com'
   acquia_id.idp_logout_redirect_uri: 'https://cloud.acquia.com'
 
 services:

--- a/docroot/modules/custom/acquia_id/acquia_id.services.yml
+++ b/docroot/modules/custom/acquia_id/acquia_id.services.yml
@@ -1,0 +1,26 @@
+parameters:
+  acquia_id.client_id: ''
+  acquia_id.idp_base_uri: ''
+  acquia_id.cloud_api_base_uri: ''
+  acquia_id.idp_logout_redirect_uri: 'https://cloud.acquia.com'
+
+services:
+  acquia_id.oauth2.provider_factory:
+    class: Drupal\acquia_id\OAuth2\ProviderFactory
+    arguments:
+      - '@http_client_factory'
+      - '%acquia_id.client_id%'
+      - '%acquia_id.idp_base_uri%'
+      - '%acquia_id.cloud_api_base_uri%'
+    public: false
+
+  acquia_id.oauth2.provider:
+    class: Drupal\acquia_id\OAuth2\Provider\AcquiaIdProvider
+    factory: ['@acquia_id.oauth2.provider_factory', 'get']
+
+  acquia_id.oauth2.access_token_repository:
+    class: Drupal\acquia_id\OAuth2\AccessTokenRepository
+    arguments:
+      - '@acquia_id.oauth2.provider_factory'
+      - '@user.data'
+      - '@datetime.time'

--- a/docroot/modules/custom/acquia_id/acquia_id.services.yml
+++ b/docroot/modules/custom/acquia_id/acquia_id.services.yml
@@ -24,3 +24,16 @@ services:
       - '@acquia_id.oauth2.provider_factory'
       - '@user.data'
       - '@datetime.time'
+
+  Drupal\acquia_id\OAuth2\LogoutResponseGenerator:
+    arguments:
+      - '%acquia_id.idp_base_uri%'
+      - '%acquia_id.idp_logout_redirect_uri%'
+      - '@acquia_id.oauth2.access_token_repository'
+      - '@current_user'
+
+  Drupal\acquia_id\EventSubscriber\LogoutRedirectSubscriber:
+    arguments:
+      - '@Drupal\acquia_id\OAuth2\LogoutResponseGenerator'
+    tags:
+      - { name: event_subscriber }

--- a/docroot/modules/custom/acquia_id/composer.json
+++ b/docroot/modules/custom/acquia_id/composer.json
@@ -1,0 +1,9 @@
+{
+    "name": "drupal/acquia_id",
+    "type": "drupal-custom-module",
+    "description": "OAuth2 single sign-on via Acquia ID (id.acquia.com).",
+    "license": "GPL-2.0-or-later",
+    "require": {
+        "league/oauth2-client": "^2"
+    }
+}

--- a/docroot/modules/custom/acquia_id/src/AcquiaIdServiceProvider.php
+++ b/docroot/modules/custom/acquia_id/src/AcquiaIdServiceProvider.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\acquia_id;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\DependencyInjection\ServiceProviderBase;
+
+final class AcquiaIdServiceProvider extends ServiceProviderBase {
+
+  public function alter(ContainerBuilder $container): void {
+    parent::alter($container);
+
+    if (getenv('AH_SITE_ENVIRONMENT') === 'prod') {
+      $idp_base_uri = 'https://id.acquia.com/oauth2/default';
+      $cloud_api_base_uri = 'https://cloud.acquia.com';
+    }
+    else {
+      $idp_base_uri = 'https://staging.id.acquia.com/oauth2/default';
+      $cloud_api_base_uri = 'https://staging.cloud.acquia.com';
+    }
+
+    $container->setParameter('acquia_id.idp_base_uri', $idp_base_uri);
+    $container->setParameter('acquia_id.cloud_api_base_uri', $cloud_api_base_uri);
+    $container->setParameter('acquia_id.idp_logout_redirect_uri', $cloud_api_base_uri);
+  }
+
+}

--- a/docroot/modules/custom/acquia_id/src/AcquiaIdServiceProvider.php
+++ b/docroot/modules/custom/acquia_id/src/AcquiaIdServiceProvider.php
@@ -6,13 +6,14 @@ namespace Drupal\acquia_id;
 
 use Drupal\Core\DependencyInjection\ContainerBuilder;
 use Drupal\Core\DependencyInjection\ServiceProviderBase;
+use Acquia\Drupal\RecommendedSettings\Helpers\EnvironmentDetector;
 
 final class AcquiaIdServiceProvider extends ServiceProviderBase {
 
   public function alter(ContainerBuilder $container): void {
     parent::alter($container);
 
-    if (getenv('AH_SITE_ENVIRONMENT') === 'prod') {
+    if (EnvironmentDetector::isProdEnv()) {
       $idp_base_uri = 'https://id.acquia.com/oauth2/default';
       $cloud_api_base_uri = 'https://cloud.acquia.com';
     }

--- a/docroot/modules/custom/acquia_id/src/Controller/OAuth2Controller.php
+++ b/docroot/modules/custom/acquia_id/src/Controller/OAuth2Controller.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\acquia_id\Controller;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Access\AccessResultInterface;
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Logger\LoggerChannelTrait;
+use Drupal\Core\Routing\TrustedRedirectResponse;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\Url;
+use Drupal\acquia_id\Events\OAuth2AuthorizationEvent;
+use Drupal\acquia_id\OAuth2\AccessTokenRepository;
+use Drupal\acquia_id\OAuth2\Provider\AcquiaIdProvider;
+use GuzzleHttp\Exception\RequestException;
+use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
+use League\OAuth2\Client\Token\AccessToken;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+final class OAuth2Controller implements ContainerInjectionInterface {
+
+  use LoggerChannelTrait;
+  use StringTranslationTrait;
+
+  private const OAUTH2_STATE = 'oauth2_state';
+  private const OAUTH2_PKCE = 'oauth2_pkce';
+
+  public function __construct(
+    private readonly AcquiaIdProvider $provider,
+    private readonly SessionInterface $session,
+    private readonly EventDispatcherInterface $eventDispatcher,
+    private readonly AccessTokenRepository $accessTokenRepository,
+    private readonly string $idpLogoutRedirectUri,
+  ) {
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): self {
+    return new self(
+      $container->get('acquia_id.oauth2.provider'),
+      $container->get('session'),
+      $container->get('event_dispatcher'),
+      $container->get('acquia_id.oauth2.access_token_repository'),
+      $container->getParameter('acquia_id.idp_logout_redirect_uri'),
+    );
+  }
+
+  /**
+   * Handles the OAuth2 authorization code PKCE flow.
+   *
+   * @link https://oauth.net/2/pkce/
+   */
+  public function __invoke(Request $request): RedirectResponse {
+    // Check if this is a subrequest being made on access denied exception.
+    // @see \Drupal\Core\EventSubscriber\HttpExceptionSubscriberBase::onException().
+    if ($request->attributes->has('exception')) {
+      $request->query->replace();
+    }
+
+    if (!$request->query->has('code') && !$request->query->has('state')) {
+      if ($request->query->has('destination')) {
+        $this->session->set('oauth2_destination', $request->query->get('destination'));
+        $request->query->set('destination', '');
+      }
+      $response = new TrustedRedirectResponse(
+        $this->provider->getAuthorizationUrl(),
+        Response::HTTP_SEE_OTHER
+      );
+      $this->session->set(self::OAUTH2_STATE, $this->provider->getState());
+      $this->session->set(self::OAUTH2_PKCE, $this->provider->getPkceCode());
+      return $response;
+    }
+
+    if (!$request->query->has('state')) {
+      throw new AccessDeniedHttpException('Missing state');
+    }
+    if ($request->query->get('state') !== $this->session->get(self::OAUTH2_STATE)) {
+      throw new AccessDeniedHttpException('Invalid state');
+    }
+
+    if ($request->query->has('error')) {
+      return $this->accessDeniedRedirect($request->query->get('error_description', ''));
+    }
+
+    try {
+      $this->provider->setPkceCode($this->session->get(self::OAUTH2_PKCE));
+      $token = $this->provider->getAccessToken('authorization_code', [
+        'code' => $request->query->get('code', ''),
+      ]);
+      assert($token instanceof AccessToken);
+    }
+    catch (\Exception $e) {
+      throw new AccessDeniedHttpException($e->getMessage(), $e);
+    }
+
+    $event = new OAuth2AuthorizationEvent($this->provider, $token);
+    try {
+      $this->eventDispatcher->dispatch($event);
+    }
+    catch (\Exception $e) {
+      return $this->accessDeniedRedirect($e->getMessage());
+    }
+
+    $user = $event->getUser();
+    if ($user === NULL) {
+      return $this->accessDeniedRedirect('User not determined from OAuth authorization.');
+    }
+
+    user_login_finalize($user);
+    $this->accessTokenRepository->store((int) $user->id(), $token);
+
+    if ($destination = $this->session->get('oauth2_destination')) {
+      $url = Url::fromUserInput($destination)->setAbsolute();
+      $this->session->remove('oauth2_destination');
+    }
+    else {
+      $url = Url::fromRoute('<front>');
+    }
+
+    return new RedirectResponse($url->toString(), Response::HTTP_SEE_OTHER);
+  }
+
+  /**
+   * Checks access for the SSO route.
+   */
+  public function access(AccountInterface $account): AccessResultInterface {
+    $token = NULL;
+    try {
+      $token = $this->accessTokenRepository->get((int) $account->id());
+    }
+    catch (IdentityProviderException) {
+      return AccessResult::allowed();
+    }
+    catch (RequestException) {
+    }
+
+    return AccessResult::allowedIf($account->isAnonymous() || $token === NULL);
+  }
+
+  private function accessDeniedRedirect(string $logMessage = 'Access denied'): RedirectResponse {
+    $this->getLogger('acquia_id')->error($this->t('Error: @message', ['@message' => $logMessage]));
+    return new TrustedRedirectResponse($this->idpLogoutRedirectUri, Response::HTTP_SEE_OTHER);
+  }
+
+}

--- a/docroot/modules/custom/acquia_id/src/EventSubscriber/LogoutRedirectSubscriber.php
+++ b/docroot/modules/custom/acquia_id/src/EventSubscriber/LogoutRedirectSubscriber.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\acquia_id\EventSubscriber;
+
+use Drupal\acquia_id\OAuth2\LogoutResponseGenerator;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Replaces the Drupal logout redirect with an IdP logout redirect.
+ *
+ * When a user logs out of Drupal, this subscriber intercepts the response on
+ * the user.logout route and replaces it with a redirect through the IdP's
+ * logout endpoint, so the OKTA session is also terminated.
+ */
+final class LogoutRedirectSubscriber implements EventSubscriberInterface {
+
+  public function __construct(
+    private readonly LogoutResponseGenerator $logoutResponseGenerator,
+  ) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    // Run early so we replace the response before other subscribers.
+    return [
+      KernelEvents::RESPONSE => ['onResponse', 100],
+    ];
+  }
+
+  /**
+   * Replaces the logout response with an IdP logout redirect.
+   */
+  public function onResponse(ResponseEvent $event): void {
+    $route_name = $event->getRequest()->attributes->get('_route');
+    if ($route_name !== 'user.logout') {
+      return;
+    }
+    $event->setResponse($this->logoutResponseGenerator->get());
+  }
+
+}

--- a/docroot/modules/custom/acquia_id/src/Events/OAuth2AuthorizationEvent.php
+++ b/docroot/modules/custom/acquia_id/src/Events/OAuth2AuthorizationEvent.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\acquia_id\Events;
+
+use Drupal\acquia_id\OAuth2\Provider\IdpProvider;
+use Drupal\user\UserInterface;
+use League\OAuth2\Client\Token\AccessToken;
+use Symfony\Contracts\EventDispatcher\Event;
+
+final class OAuth2AuthorizationEvent extends Event {
+
+  private UserInterface|null $user = NULL;
+
+  public function __construct(
+    private readonly IdpProvider $provider,
+    private readonly AccessToken $accessToken,
+  ) {
+  }
+
+  public function getProvider(): IdpProvider {
+    return $this->provider;
+  }
+
+  public function getAccessToken(): AccessToken {
+    return $this->accessToken;
+  }
+
+  public function setUser(UserInterface $user): void {
+    $this->user = $user;
+  }
+
+  public function getUser(): ?UserInterface {
+    return $this->user;
+  }
+
+}

--- a/docroot/modules/custom/acquia_id/src/Events/OAuth2AuthorizationEvent.php
+++ b/docroot/modules/custom/acquia_id/src/Events/OAuth2AuthorizationEvent.php
@@ -14,17 +14,9 @@ final class OAuth2AuthorizationEvent extends Event {
   private UserInterface|null $user = NULL;
 
   public function __construct(
-    private readonly IdpProvider $provider,
-    private readonly AccessToken $accessToken,
+    public readonly IdpProvider $provider,
+    public readonly AccessToken $accessToken,
   ) {
-  }
-
-  public function getProvider(): IdpProvider {
-    return $this->provider;
-  }
-
-  public function getAccessToken(): AccessToken {
-    return $this->accessToken;
   }
 
   public function setUser(UserInterface $user): void {

--- a/docroot/modules/custom/acquia_id/src/OAuth2/AccessTokenRepository.php
+++ b/docroot/modules/custom/acquia_id/src/OAuth2/AccessTokenRepository.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\acquia_id\OAuth2;
+
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\user\UserDataInterface;
+use League\OAuth2\Client\Token\AccessToken;
+
+final class AccessTokenRepository {
+
+  /**
+   * The refresh token TTL from Acquia Cloud is 90 minutes.
+   */
+  private const REFRESH_TOKEN_TTL = 90;
+
+  private const string STORAGE_KEY = 'acquia_id_access_token';
+
+  public function __construct(
+    private readonly ProviderFactory $providerFactory,
+    private readonly UserDataInterface $userData,
+    private readonly TimeInterface $time,
+  ) {}
+
+  /**
+   * Gets the access token for the given user, refreshing it if expired.
+   *
+   * @throws \League\OAuth2\Client\Provider\Exception\IdentityProviderException
+   */
+  public function get(int $id): ?AccessToken {
+    $tokenData = $this->userData->get('acquia_id', $id, self::STORAGE_KEY);
+
+    if (empty($tokenData) ||
+      ($tokenData['timestamp'] < ($this->time->getCurrentTime() - (self::REFRESH_TOKEN_TTL * 60)))) {
+      return NULL;
+    }
+
+    $token = $tokenData['access_token'];
+    if ($token->hasExpired()) {
+      /** @var \League\OAuth2\Client\Token\AccessToken $token */
+      $token = $this->providerFactory->get()->getAccessToken('refresh_token', [
+        'refresh_token' => $token->getRefreshToken() ?? '',
+      ]);
+      $this->store($id, $token);
+    }
+
+    return $token;
+  }
+
+  public function store(int $id, AccessToken $token): void {
+    $this->userData->set('acquia_id', $id, self::STORAGE_KEY, [
+      'access_token' => $token,
+      'timestamp' => $this->time->getCurrentTime(),
+    ]);
+  }
+
+  public function delete(int $id): void {
+    $this->userData->delete('acquia_id', $id, self::STORAGE_KEY);
+  }
+
+  /**
+   * @return list<int|string>
+   */
+  public function getUserIdsWithTokens(): array {
+    return array_keys($this->userData->get('acquia_id', name: self::STORAGE_KEY));
+  }
+
+}

--- a/docroot/modules/custom/acquia_id/src/OAuth2/LogoutResponseGenerator.php
+++ b/docroot/modules/custom/acquia_id/src/OAuth2/LogoutResponseGenerator.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\acquia_id\OAuth2;
+
+use Drupal\Core\Routing\TrustedRedirectResponse;
+use Drupal\Core\Session\AccountInterface;
+use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
+
+final readonly class LogoutResponseGenerator {
+
+  public function __construct(
+    private string $idpBaseUri,
+    private string $idpLogoutRedirectUri,
+    private AccessTokenRepository $accessTokenRepository,
+    private AccountInterface $account,
+  ) {}
+
+  /**
+   * Gets the logout redirect response.
+   *
+   * Redirects through the IdP logout endpoint when a valid token with an
+   * id_token is available, so the OKTA session is terminated alongside the
+   * Drupal session.
+   */
+  public function get(): TrustedRedirectResponse {
+    try {
+      $token = $this->accessTokenRepository->get((int) $this->account->id());
+      if ($token) {
+        $id_token = $token->getValues()['id_token'] ?? '';
+        $logout_url = $this->idpBaseUri . "/v1/logout?id_token_hint=$id_token&post_logout_redirect_uri=$this->idpLogoutRedirectUri";
+      }
+      else {
+        $logout_url = $this->idpLogoutRedirectUri;
+      }
+    }
+    catch (IdentityProviderException) {
+      $logout_url = $this->idpLogoutRedirectUri;
+    }
+
+    $response = new TrustedRedirectResponse($logout_url);
+    $response
+      ->getCacheableMetadata()
+      ->setCacheMaxAge(0);
+    return $response;
+  }
+
+}

--- a/docroot/modules/custom/acquia_id/src/OAuth2/Provider/AcquiaIdProvider.php
+++ b/docroot/modules/custom/acquia_id/src/OAuth2/Provider/AcquiaIdProvider.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\acquia_id\OAuth2\Provider;
+
+use League\OAuth2\Client\Provider\ResourceOwnerInterface;
+use League\OAuth2\Client\Token\AccessToken;
+
+/**
+ * OAuth2 provider for Acquia ID (id.acquia.com).
+ */
+final class AcquiaIdProvider extends IdpProvider {
+
+  private string $idpBaseUri;
+
+  private string $cloudApiBaseUri;
+
+  public function setIdpBaseUri(string $baseUri): self {
+    $this->idpBaseUri = $baseUri;
+    return $this;
+  }
+
+  public function setCloudApiBaseUri(string $baseUri): self {
+    $this->cloudApiBaseUri = $baseUri;
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getBaseAuthorizationUrl(): string {
+    return "$this->idpBaseUri/v1/authorize";
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getBaseAccessTokenUrl(array $params): string {
+    return "$this->idpBaseUri/v1/token";
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getResourceOwnerDetailsUrl(AccessToken $token): string {
+    return $this->cloudApiBaseUri . '/api/account';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function createResourceOwner(array $response, AccessToken $token): ResourceOwnerInterface {
+    return new AcquiaIdResourceOwner($response);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getDefaultScopes(): array {
+    return [
+      'openid',
+      'email',
+      'profile',
+      'offline_access',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getScopeSeparator(): string {
+    return ' ';
+  }
+
+}

--- a/docroot/modules/custom/acquia_id/src/OAuth2/Provider/AcquiaIdProvider.php
+++ b/docroot/modules/custom/acquia_id/src/OAuth2/Provider/AcquiaIdProvider.php
@@ -10,7 +10,7 @@ use League\OAuth2\Client\Token\AccessToken;
 /**
  * OAuth2 provider for Acquia ID (id.acquia.com).
  */
-final class AcquiaIdProvider extends IdpProvider {
+class AcquiaIdProvider extends IdpProvider {
 
   private string $idpBaseUri;
 

--- a/docroot/modules/custom/acquia_id/src/OAuth2/Provider/AcquiaIdResourceOwner.php
+++ b/docroot/modules/custom/acquia_id/src/OAuth2/Provider/AcquiaIdResourceOwner.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\acquia_id\OAuth2\Provider;
+
+use League\OAuth2\Client\Provider\ResourceOwnerInterface;
+
+/**
+ * Represents the authenticated user from Acquia ID.
+ *
+ * @phpstan-type Account array{mail: string, timezone: string, uuid: string, first_name?: string, last_name?: string, company?: string, zoneinfo?: string, sub?: string}
+ */
+final class AcquiaIdResourceOwner implements ResourceOwnerInterface {
+
+  /**
+   * @phpstan-param Account $response
+   */
+  public function __construct(
+    private readonly array $response,
+  ) {
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getId(): string {
+    return $this->response['mail'];
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * @phpstan-return Account
+   */
+  public function toArray(): array {
+    return $this->response;
+  }
+
+}

--- a/docroot/modules/custom/acquia_id/src/OAuth2/Provider/IdpProvider.php
+++ b/docroot/modules/custom/acquia_id/src/OAuth2/Provider/IdpProvider.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\acquia_id\OAuth2\Provider;
+
+use League\OAuth2\Client\Provider\AbstractProvider;
+use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
+use League\OAuth2\Client\Tool\BearerAuthorizationTrait;
+use Psr\Http\Message\ResponseInterface;
+
+abstract class IdpProvider extends AbstractProvider {
+
+  use BearerAuthorizationTrait;
+
+  /**
+   * {@inheritdoc}
+   *
+   * @return string[]
+   */
+  protected function getDefaultScopes(): array {
+    return [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getPkceMethod(): string {
+    return self::PKCE_METHOD_S256;
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * @phpcs:disable SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
+   */
+  protected function checkResponse(ResponseInterface $response, $data): void {
+    if ($response->getStatusCode() >= 400) {
+      throw new IdentityProviderException(
+        $response->getReasonPhrase(),
+        $response->getStatusCode(),
+        $response
+      );
+    }
+  }
+
+}

--- a/docroot/modules/custom/acquia_id/src/OAuth2/ProviderFactory.php
+++ b/docroot/modules/custom/acquia_id/src/OAuth2/ProviderFactory.php
@@ -8,7 +8,7 @@ use Drupal\Core\Http\ClientFactory;
 use Drupal\Core\Url;
 use Drupal\acquia_id\OAuth2\Provider\AcquiaIdProvider;
 
-final class ProviderFactory {
+class ProviderFactory {
 
   public function __construct(
     private readonly ClientFactory $httpClientFactory,

--- a/docroot/modules/custom/acquia_id/src/OAuth2/ProviderFactory.php
+++ b/docroot/modules/custom/acquia_id/src/OAuth2/ProviderFactory.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\acquia_id\OAuth2;
+
+use Drupal\Core\Http\ClientFactory;
+use Drupal\Core\Url;
+use Drupal\acquia_id\OAuth2\Provider\AcquiaIdProvider;
+
+final class ProviderFactory {
+
+  public function __construct(
+    private readonly ClientFactory $httpClientFactory,
+    private readonly string $clientId,
+    private readonly string $idpBaseUri,
+    private readonly string $cloudApiBaseUri,
+  ) {
+  }
+
+  public function get(): AcquiaIdProvider {
+    $provider = new AcquiaIdProvider([
+      'clientId' => $this->clientId,
+      'redirectUri' => $this->getRedirectUri(),
+    ]);
+    $provider
+      ->setIdpBaseUri($this->idpBaseUri)
+      ->setCloudApiBaseUri($this->cloudApiBaseUri)
+      ->setHttpClient($this->httpClientFactory->fromOptions());
+    return $provider;
+  }
+
+  private function getRedirectUri(): string {
+    return Url::fromRoute('acquia_id.sso')
+      ->setAbsolute()
+      ->toString(TRUE)
+      ->getGeneratedUrl();
+  }
+
+}

--- a/docroot/modules/custom/acquia_id/tests/src/Kernel/Controller/OAuth2ControllerTest.php
+++ b/docroot/modules/custom/acquia_id/tests/src/Kernel/Controller/OAuth2ControllerTest.php
@@ -7,6 +7,8 @@ namespace Drupal\Tests\acquia_id\Kernel\Controller;
 use Drupal\Core\DependencyInjection\ContainerBuilder;
 use Drupal\Core\Url;
 use Drupal\KernelTests\KernelTestBase;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder as SymfonyContainerBuilder;
 use Drupal\Tests\acquia_id\Kernel\HttpClientMiddleware\MockedCloudApiMiddleware;
 use Drupal\Tests\acquia_id\Kernel\HttpClientMiddleware\MockedIdpMiddleware;
 use Drupal\Tests\user\Traits\UserCreationTrait;
@@ -62,6 +64,15 @@ class OAuth2ControllerTest extends KernelTestBase {
     $container->register('http_kernel.test', TestHttpKernel::class)
       ->setDecoratedService('http_kernel.basic')
       ->addArgument(new \Symfony\Component\DependencyInjection\Reference('http_kernel.test.inner'));
+
+    // Override after AcquiaIdServiceProvider::alter() sets staging URLs.
+    $container->addCompilerPass(new class implements CompilerPassInterface {
+      public function process(SymfonyContainerBuilder $container): void {
+        $container->setParameter('acquia_id.idp_base_uri', 'https://id.acquia.com/oauth2/default');
+        $container->setParameter('acquia_id.cloud_api_base_uri', 'https://cloud.acquia.com');
+        $container->setParameter('acquia_id.idp_logout_redirect_uri', 'https://cloud.acquia.com');
+      }
+    }, priority: -200);
   }
 
   public function testInitialVisitRedirectsToIdp(): void {

--- a/docroot/modules/custom/acquia_id/tests/src/Kernel/Controller/OAuth2ControllerTest.php
+++ b/docroot/modules/custom/acquia_id/tests/src/Kernel/Controller/OAuth2ControllerTest.php
@@ -72,7 +72,7 @@ class OAuth2ControllerTest extends KernelTestBase {
     $this->assertSame(Response::HTTP_SEE_OTHER, $response->getStatusCode());
     $location = $response->headers->get('Location');
     $this->assertStringContainsString(
-      'https://id.acquia.com/oauth2/default/v1/authorize',
+      'id.acquia.com/oauth2/default/v1/authorize',
       $location,
     );
     $this->assertStringContainsString('code_challenge=', $location);
@@ -96,7 +96,7 @@ class OAuth2ControllerTest extends KernelTestBase {
 
     $this->assertSame(Response::HTTP_SEE_OTHER, $response->getStatusCode());
     $this->assertStringContainsString(
-      'https://id.acquia.com/oauth2/default/v1/authorize',
+      'id.acquia.com/oauth2/default/v1/authorize',
       $response->headers->get('Location'),
     );
   }
@@ -146,7 +146,7 @@ class OAuth2ControllerTest extends KernelTestBase {
     $this->assertTrue($response->isRedirect());
     $this->assertSame(Response::HTTP_SEE_OTHER, $response->getStatusCode());
     $this->assertStringContainsString(
-      'https://cloud.acquia.com',
+      'cloud.acquia.com',
       $response->headers->get('Location'),
     );
   }
@@ -163,7 +163,7 @@ class OAuth2ControllerTest extends KernelTestBase {
     $response = $this->doRequest($request);
 
     $this->assertStringContainsString(
-      'https://id.acquia.com/oauth2/default/v1/authorize',
+      'id.acquia.com/oauth2/default/v1/authorize',
       $response->headers->get('Location'),
     );
   }

--- a/docroot/modules/custom/acquia_id/tests/src/Kernel/Controller/OAuth2ControllerTest.php
+++ b/docroot/modules/custom/acquia_id/tests/src/Kernel/Controller/OAuth2ControllerTest.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\acquia_id\Kernel\Controller;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\Url;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\acquia_id\Kernel\HttpClientMiddleware\MockedCloudApiMiddleware;
+use Drupal\Tests\acquia_id\Kernel\HttpClientMiddleware\MockedIdpMiddleware;
+use Drupal\Tests\user\Traits\UserCreationTrait;
+use League\OAuth2\Client\Token\AccessToken;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use Drupal\acquia_id\Controller\OAuth2Controller;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+#[CoversClass(OAuth2Controller::class)]
+#[Group('acquia_id')]
+class OAuth2ControllerTest extends KernelTestBase {
+
+  use UserCreationTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'acquia_id',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installSchema('user', ['users_data']);
+    $this->installConfig('system');
+    // Create uid 1.
+    $this->createUser();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function register(ContainerBuilder $container): void {
+    parent::register($container);
+    $container->register(MockedIdpMiddleware::class)
+      ->addTag('http_client_middleware');
+    $container->register(MockedCloudApiMiddleware::class)
+      ->addTag('http_client_middleware');
+  }
+
+  public function testInitialVisitRedirectsToIdp(): void {
+    $response = $this->doRequest(
+      Request::create(Url::fromRoute('acquia_id.sso')->toString()),
+    );
+
+    $this->assertSame(Response::HTTP_SEE_OTHER, $response->getStatusCode());
+    $location = $response->headers->get('Location');
+    $this->assertStringContainsString(
+      'https://id.acquia.com/oauth2/default/v1/authorize',
+      $location,
+    );
+    $this->assertStringContainsString('code_challenge=', $location);
+    $this->assertStringContainsString('code_challenge_method=S256', $location);
+    $this->assertStringContainsString('scope=openid+email+profile+offline_access', $location);
+  }
+
+  public function testDestinationIsPreservedInSession(): void {
+    $response = $this->doRequest(
+      Request::create(Url::fromRoute('acquia_id.sso', [], [
+        'query' => ['destination' => '/admin'],
+      ])->toString()),
+    );
+
+    $this->assertSame(Response::HTTP_SEE_OTHER, $response->getStatusCode());
+    $this->assertStringContainsString(
+      'https://id.acquia.com/oauth2/default/v1/authorize',
+      $response->headers->get('Location'),
+    );
+  }
+
+  public function testMissingStateThrowsAccessDenied(): void {
+    $this->expectException(AccessDeniedHttpException::class);
+    $this->expectExceptionMessage('Missing state');
+
+    $this->doRequest(
+      Request::create(Url::fromRoute('acquia_id.sso', [], [
+        'query' => ['code' => 'some-code'],
+      ])->toString()),
+    );
+  }
+
+  public function testMismatchedStateThrowsAccessDenied(): void {
+    $this->expectException(AccessDeniedHttpException::class);
+    $this->expectExceptionMessage('Invalid state');
+
+    $this->doRequest(
+      Request::create(Url::fromRoute('acquia_id.sso', [], [
+        'query' => [
+          'code' => 'some-code',
+          'state' => 'wrong-state',
+        ],
+      ])->toString()),
+    );
+  }
+
+  public function testErrorFromIdpRedirectsToLogoutUri(): void {
+    // First, initiate the flow to set state in session.
+    $this->doRequest(
+      Request::create(Url::fromRoute('acquia_id.sso')->toString()),
+    );
+
+    $state = $this->container->get('session')->get('oauth2_state');
+    $response = $this->doRequest(
+      Request::create(Url::fromRoute('acquia_id.sso', [], [
+        'query' => [
+          'state' => $state,
+          'error' => 'invalid_client',
+          'error_description' => 'Client authentication failed.',
+        ],
+      ])->toString()),
+    );
+
+    $this->assertTrue($response->isRedirect());
+    $this->assertSame(Response::HTTP_SEE_OTHER, $response->getStatusCode());
+    $this->assertStringContainsString(
+      'https://cloud.acquia.com',
+      $response->headers->get('Location'),
+    );
+  }
+
+  public function testExceptionSubrequestResetsQueryParams(): void {
+    $request = Request::create(Url::fromRoute('acquia_id.sso', [], [
+      'query' => [
+        'code' => '1234',
+        'state' => 'ABCD',
+      ],
+    ])->toString());
+    $request->attributes->set('exception', new \Exception());
+
+    $response = $this->doRequest($request);
+
+    $this->assertStringContainsString(
+      'https://id.acquia.com/oauth2/default/v1/authorize',
+      $response->headers->get('Location'),
+    );
+  }
+
+  public function testSsoRouteAccessAnonymousAllowed(): void {
+    $access_manager = $this->container->get('access_manager');
+    $result = $access_manager->checkNamedRoute('acquia_id.sso', []);
+    $this->assertTrue($result);
+  }
+
+  public function testSsoRouteAccessAuthenticatedWithoutTokenAllowed(): void {
+    $access_manager = $this->container->get('access_manager');
+    $user = $this->setUpCurrentUser();
+    $result = $access_manager->checkNamedRoute('acquia_id.sso', [], $user);
+    $this->assertTrue($result);
+  }
+
+  public function testSsoRouteAccessAuthenticatedWithTokenDenied(): void {
+    $access_manager = $this->container->get('access_manager');
+    $user = $this->setUpCurrentUser();
+
+    // Store a valid access token for this user.
+    $token = new AccessToken([
+      'access_token' => 'VALID_ACCESS_TOKEN',
+      'expires' => time() + 3600,
+    ]);
+    $this->container->get('user.data')
+      ->set('acquia_id', $user->id(), 'acquia_id_access_token', [
+        'access_token' => $token,
+        'timestamp' => time(),
+      ]);
+
+    $result = $access_manager->checkNamedRoute('acquia_id.sso', [], $user);
+    $this->assertFalse($result);
+  }
+
+  /**
+   * Makes an HTTP request through the kernel.
+   */
+  private function doRequest(Request $request): Response {
+    $request_stack = $this->container->get('request_stack');
+    while ($request_stack->getCurrentRequest() !== NULL) {
+      $request_stack->pop();
+    }
+
+    $http_kernel = $this->container->get('http_kernel');
+    return $http_kernel->handle($request);
+  }
+
+}

--- a/docroot/modules/custom/acquia_id/tests/src/Kernel/Controller/OAuth2ControllerTest.php
+++ b/docroot/modules/custom/acquia_id/tests/src/Kernel/Controller/OAuth2ControllerTest.php
@@ -13,13 +13,16 @@ use Drupal\Tests\user\Traits\UserCreationTrait;
 use League\OAuth2\Client\Token\AccessToken;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Drupal\acquia_id\Controller\OAuth2Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\TerminableInterface;
 
 #[CoversClass(OAuth2Controller::class)]
 #[Group('acquia_id')]
+#[RunTestsInSeparateProcesses]
 class OAuth2ControllerTest extends KernelTestBase {
 
   use UserCreationTrait;
@@ -54,6 +57,11 @@ class OAuth2ControllerTest extends KernelTestBase {
       ->addTag('http_client_middleware');
     $container->register(MockedCloudApiMiddleware::class)
       ->addTag('http_client_middleware');
+    // Decorate the HTTP kernel so exceptions propagate to the test rather than
+    // being caught by Drupal's exception subscribers.
+    $container->register('http_kernel.test', TestHttpKernel::class)
+      ->setDecoratedService('http_kernel.basic')
+      ->addArgument(new \Symfony\Component\DependencyInjection\Reference('http_kernel.test.inner'));
   }
 
   public function testInitialVisitRedirectsToIdp(): void {
@@ -69,7 +77,14 @@ class OAuth2ControllerTest extends KernelTestBase {
     );
     $this->assertStringContainsString('code_challenge=', $location);
     $this->assertStringContainsString('code_challenge_method=S256', $location);
-    $this->assertStringContainsString('scope=openid+email+profile+offline_access', $location);
+
+    // Verify scopes are present (URL may encode spaces as %20 or +).
+    $query = parse_url($location, PHP_URL_QUERY);
+    parse_str($query, $params);
+    $this->assertStringContainsString('openid', $params['scope']);
+    $this->assertStringContainsString('email', $params['scope']);
+    $this->assertStringContainsString('profile', $params['scope']);
+    $this->assertStringContainsString('offline_access', $params['scope']);
   }
 
   public function testDestinationIsPreservedInSession(): void {
@@ -87,7 +102,7 @@ class OAuth2ControllerTest extends KernelTestBase {
   }
 
   public function testMissingStateThrowsAccessDenied(): void {
-    $this->expectException(AccessDeniedHttpException::class);
+    $this->expectException(\Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException::class);
     $this->expectExceptionMessage('Missing state');
 
     $this->doRequest(
@@ -98,7 +113,7 @@ class OAuth2ControllerTest extends KernelTestBase {
   }
 
   public function testMismatchedStateThrowsAccessDenied(): void {
-    $this->expectException(AccessDeniedHttpException::class);
+    $this->expectException(\Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException::class);
     $this->expectExceptionMessage('Invalid state');
 
     $this->doRequest(
@@ -196,6 +211,31 @@ class OAuth2ControllerTest extends KernelTestBase {
 
     $http_kernel = $this->container->get('http_kernel');
     return $http_kernel->handle($request);
+  }
+
+}
+
+/**
+ * HTTP kernel decorator that lets exceptions propagate to the test.
+ */
+final class TestHttpKernel implements HttpKernelInterface, TerminableInterface {
+
+  public function __construct(
+    private readonly HttpKernelInterface $httpKernel,
+  ) {}
+
+  public function handle(
+    Request $request,
+    int $type = self::MAIN_REQUEST,
+    bool $catch = TRUE,
+  ): Response {
+    return $this->httpKernel->handle($request, $type, FALSE);
+  }
+
+  public function terminate(Request $request, Response $response): void {
+    if ($this->httpKernel instanceof TerminableInterface) {
+      $this->httpKernel->terminate($request, $response);
+    }
   }
 
 }

--- a/docroot/modules/custom/acquia_id/tests/src/Kernel/HttpClientMiddleware/MockedCloudApiMiddleware.php
+++ b/docroot/modules/custom/acquia_id/tests/src/Kernel/HttpClientMiddleware/MockedCloudApiMiddleware.php
@@ -44,7 +44,16 @@ final class MockedCloudApiMiddleware {
           );
         }
 
-        // Application access check endpoint.
+        // Application access check endpoint (reject empty UUID path).
+        if ($path === '/api/applications/' || $path === '/api/applications') {
+          return new FulfilledPromise(
+            new Response(
+              404,
+              ['Content-Type' => 'application/json'],
+              Json::encode(['error' => 'Not Found']),
+            ),
+          );
+        }
         if (preg_match('#^/api/applications/(.+)$#', $path, $matches)) {
           if ($access_token === 'NO_APP_ACCESS_TOKEN') {
             return new FulfilledPromise(

--- a/docroot/modules/custom/acquia_id/tests/src/Kernel/HttpClientMiddleware/MockedCloudApiMiddleware.php
+++ b/docroot/modules/custom/acquia_id/tests/src/Kernel/HttpClientMiddleware/MockedCloudApiMiddleware.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\acquia_id\Kernel\HttpClientMiddleware;
+
+use Drupal\Component\Serialization\Json;
+use GuzzleHttp\Promise\FulfilledPromise;
+use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Psr7\Response;
+use Psr\Http\Message\RequestInterface;
+
+/**
+ * Guzzle middleware that intercepts requests to the Acquia Cloud API.
+ *
+ * Mocks /api/account and /api/applications/{uuid} endpoints.
+ */
+final class MockedCloudApiMiddleware {
+
+  public function __invoke(): callable {
+    return static function (callable $handler): callable {
+      return static function (RequestInterface $request, array $options) use ($handler): PromiseInterface {
+        if ($request->getUri()->getHost() !== 'cloud.acquia.com') {
+          return $handler($request, $options);
+        }
+
+        $path = $request->getUri()->getPath();
+        $access_token = str_replace('Bearer ', '', $request->getHeaderLine('Authorization'));
+
+        // Resource owner details endpoint.
+        if ($path === '/api/account') {
+          return new FulfilledPromise(
+            new Response(
+              200,
+              ['Content-Type' => 'application/json'],
+              Json::encode([
+                'uuid' => 'user-uuid-12345',
+                'mail' => 'test@example.com',
+                'timezone' => 'America/New_York',
+                'first_name' => 'Test',
+                'last_name' => 'User',
+              ]),
+            ),
+          );
+        }
+
+        // Application access check endpoint.
+        if (preg_match('#^/api/applications/(.+)$#', $path, $matches)) {
+          if ($access_token === 'NO_APP_ACCESS_TOKEN') {
+            return new FulfilledPromise(
+              new Response(
+                403,
+                ['Content-Type' => 'application/json'],
+                Json::encode(['error' => 'Forbidden']),
+              ),
+            );
+          }
+          return new FulfilledPromise(
+            new Response(
+              200,
+              ['Content-Type' => 'application/json'],
+              Json::encode([
+                'uuid' => $matches[1],
+                'name' => 'Test Application',
+              ]),
+            ),
+          );
+        }
+
+        throw new \RuntimeException(__CLASS__ . ' request URI not mocked: ' . $request->getUri());
+      };
+    };
+  }
+
+}

--- a/docroot/modules/custom/acquia_id/tests/src/Kernel/HttpClientMiddleware/MockedIdpMiddleware.php
+++ b/docroot/modules/custom/acquia_id/tests/src/Kernel/HttpClientMiddleware/MockedIdpMiddleware.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\acquia_id\Kernel\HttpClientMiddleware;
+
+use Drupal\Component\Serialization\Json;
+use GuzzleHttp\Promise\FulfilledPromise;
+use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Psr7\Response;
+use Psr\Http\Message\RequestInterface;
+
+/**
+ * Guzzle middleware that intercepts requests to the Acquia ID IdP.
+ *
+ * Mocks the OKTA token endpoint for kernel tests.
+ */
+final class MockedIdpMiddleware {
+
+  public function __invoke(): callable {
+    return static function (callable $handler): callable {
+      return static function (RequestInterface $request, array $options) use ($handler): PromiseInterface {
+        if ($request->getUri()->getHost() !== 'id.acquia.com') {
+          return $handler($request, $options);
+        }
+        $path = $request->getUri()->getPath();
+
+        if ($path === '/oauth2/default/v1/token') {
+          $params = [];
+          parse_str((string) $request->getBody(), $params);
+
+          if ($params['grant_type'] === 'authorization_code') {
+            if ($params['code'] === 'CLIENT_ERROR') {
+              return new FulfilledPromise(
+                new Response(
+                  403,
+                  ['Content-Type' => 'application/json'],
+                  Json::encode(['error' => 'Forbidden']),
+                ),
+              );
+            }
+            if ($params['code'] === 'NO_APP_ACCESS') {
+              $access_token = 'NO_APP_ACCESS_TOKEN';
+            }
+            else {
+              $access_token = 'VALID_ACCESS_TOKEN';
+            }
+            return new FulfilledPromise(
+              new Response(
+                200,
+                ['Content-Type' => 'application/json'],
+                Json::encode([
+                  'access_token' => $access_token,
+                  'refresh_token' => 'REFRESH_TOKEN',
+                  'id_token' => 'eyJhbGciOiJSUzI1NiJ9.test-id-token',
+                  'expires_in' => 3600,
+                  'token_type' => 'Bearer',
+                ]),
+              ),
+            );
+          }
+
+          if ($params['grant_type'] === 'refresh_token') {
+            if ($params['refresh_token'] === 'REFRESH_TOKEN_INVALID') {
+              return new FulfilledPromise(
+                new Response(
+                  401,
+                  ['Content-Type' => 'application/json'],
+                  Json::encode([
+                    'error' => 'invalid_grant',
+                    'error_description' => 'The refresh token is invalid.',
+                  ]),
+                ),
+              );
+            }
+            return new FulfilledPromise(
+              new Response(
+                200,
+                ['Content-Type' => 'application/json'],
+                Json::encode([
+                  'access_token' => 'REFRESHED_ACCESS_TOKEN',
+                  'refresh_token' => 'REFRESHED_REFRESH_TOKEN',
+                  'expires_in' => 3600,
+                  'token_type' => 'Bearer',
+                ]),
+              ),
+            );
+          }
+        }
+
+        throw new \RuntimeException(__CLASS__ . ' request URI not mocked: ' . $request->getUri());
+      };
+    };
+  }
+
+}

--- a/docroot/modules/custom/acquia_id/tests/src/Unit/Events/OAuth2AuthorizationEventTest.php
+++ b/docroot/modules/custom/acquia_id/tests/src/Unit/Events/OAuth2AuthorizationEventTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\acquia_id\Unit\Events;
+
+use Drupal\acquia_id\Events\OAuth2AuthorizationEvent;
+use Drupal\acquia_id\OAuth2\Provider\IdpProvider;
+use Drupal\Tests\UnitTestCase;
+use Drupal\user\UserInterface;
+use League\OAuth2\Client\Token\AccessToken;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
+#[CoversClass(OAuth2AuthorizationEvent::class)]
+#[Group('acquia_id')]
+class OAuth2AuthorizationEventTest extends UnitTestCase {
+
+  public function testUserIsNullByDefault(): void {
+    $event = new OAuth2AuthorizationEvent(
+      $this->createMock(IdpProvider::class),
+      new AccessToken(['access_token' => 'test', 'expires_in' => 3600]),
+    );
+    $this->assertNull($event->getUser());
+  }
+
+  public function testSetAndGetUser(): void {
+    $event = new OAuth2AuthorizationEvent(
+      $this->createMock(IdpProvider::class),
+      new AccessToken(['access_token' => 'test', 'expires_in' => 3600]),
+    );
+    $user = $this->createMock(UserInterface::class);
+    $event->setUser($user);
+    $this->assertSame($user, $event->getUser());
+  }
+
+  public function testProviderAndTokenAreAccessible(): void {
+    $provider = $this->createMock(IdpProvider::class);
+    $token = new AccessToken(['access_token' => 'tok-123', 'expires_in' => 3600]);
+    $event = new OAuth2AuthorizationEvent($provider, $token);
+
+    $this->assertSame($provider, $event->provider);
+    $this->assertSame($token, $event->accessToken);
+  }
+
+}

--- a/docroot/modules/custom/acquia_id/tests/src/Unit/OAuth2/AccessTokenRepositoryTest.php
+++ b/docroot/modules/custom/acquia_id/tests/src/Unit/OAuth2/AccessTokenRepositoryTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\acquia_id\Unit\OAuth2;
+
+use Drupal\acquia_id\OAuth2\AccessTokenRepository;
+use Drupal\acquia_id\OAuth2\Provider\AcquiaIdProvider;
+use Drupal\acquia_id\OAuth2\ProviderFactory;
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Tests\UnitTestCase;
+use Drupal\user\UserDataInterface;
+use League\OAuth2\Client\Token\AccessToken;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
+#[CoversClass(AccessTokenRepository::class)]
+#[Group('acquia_id')]
+class AccessTokenRepositoryTest extends UnitTestCase {
+
+  private UserDataInterface $userData;
+  private TimeInterface $time;
+  private ProviderFactory $providerFactory;
+  private AccessTokenRepository $repository;
+
+  protected function setUp(): void {
+    parent::setUp();
+    $this->userData = $this->createMock(UserDataInterface::class);
+    $this->time = $this->createMock(TimeInterface::class);
+    $this->providerFactory = $this->createMock(ProviderFactory::class);
+    $this->repository = new AccessTokenRepository(
+      $this->providerFactory,
+      $this->userData,
+      $this->time,
+    );
+  }
+
+  public function testStoreWritesTokenToUserData(): void {
+    $token = new AccessToken(['access_token' => 'tok-abc', 'expires_in' => 3600]);
+    $this->time->method('getCurrentTime')->willReturn(1000000);
+
+    $this->userData->expects($this->once())
+      ->method('set')
+      ->with('acquia_id', 42, 'acquia_id_access_token', [
+        'access_token' => $token,
+        'timestamp' => 1000000,
+      ]);
+
+    $this->repository->store(42, $token);
+  }
+
+  public function testGetReturnsNullWhenNoTokenStored(): void {
+    $this->userData->method('get')
+      ->with('acquia_id', 42, 'acquia_id_access_token')
+      ->willReturn(NULL);
+
+    $this->assertNull($this->repository->get(42));
+  }
+
+  public function testGetReturnsNullWhenRefreshTokenTtlExceeded(): void {
+    $now = 1000000;
+    // Stored 91 minutes ago (exceeds 90-minute refresh TTL).
+    $storedAt = $now - (91 * 60);
+
+    $this->time->method('getCurrentTime')->willReturn($now);
+    $this->userData->method('get')
+      ->with('acquia_id', 42, 'acquia_id_access_token')
+      ->willReturn([
+        'access_token' => new AccessToken([
+          'access_token' => 'tok-old',
+          'expires_in' => 3600,
+        ]),
+        'timestamp' => $storedAt,
+      ]);
+
+    $this->assertNull($this->repository->get(42));
+  }
+
+  public function testGetReturnsTokenWhenValid(): void {
+    $now = 1000000;
+    $token = new AccessToken([
+      'access_token' => 'tok-valid',
+      // Expires well in the future.
+      'expires' => $now + 3600,
+    ]);
+
+    $this->time->method('getCurrentTime')->willReturn($now);
+    $this->userData->method('get')
+      ->with('acquia_id', 42, 'acquia_id_access_token')
+      ->willReturn([
+        'access_token' => $token,
+        'timestamp' => $now,
+      ]);
+
+    $result = $this->repository->get(42);
+    $this->assertSame($token, $result);
+  }
+
+  public function testGetRefreshesExpiredToken(): void {
+    $now = 1000000;
+    $expiredToken = new AccessToken([
+      'access_token' => 'tok-expired',
+      // Already expired (negative TTL).
+      'expires_in' => -10,
+      'refresh_token' => 'refresh-123',
+    ]);
+    // Stored recently (within 90-minute window).
+    $storedAt = $now - 60;
+
+    $this->time->method('getCurrentTime')->willReturn($now);
+    $this->userData->method('get')
+      ->with('acquia_id', 42, 'acquia_id_access_token')
+      ->willReturn([
+        'access_token' => $expiredToken,
+        'timestamp' => $storedAt,
+      ]);
+
+    $refreshedToken = new AccessToken([
+      'access_token' => 'tok-refreshed',
+      'expires' => $now + 3600,
+    ]);
+
+    $provider = $this->createMock(AcquiaIdProvider::class);
+    $provider->expects($this->once())
+      ->method('getAccessToken')
+      ->with('refresh_token', ['refresh_token' => 'refresh-123'])
+      ->willReturn($refreshedToken);
+
+    $this->providerFactory->method('get')->willReturn($provider);
+
+    // Expect the refreshed token to be stored.
+    $this->userData->expects($this->once())
+      ->method('set')
+      ->with('acquia_id', 42, 'acquia_id_access_token', [
+        'access_token' => $refreshedToken,
+        'timestamp' => $now,
+      ]);
+
+    $result = $this->repository->get(42);
+    $this->assertSame('tok-refreshed', $result->getToken());
+  }
+
+  public function testDeleteRemovesTokenData(): void {
+    $this->userData->expects($this->once())
+      ->method('delete')
+      ->with('acquia_id', 42, 'acquia_id_access_token');
+
+    $this->repository->delete(42);
+  }
+
+  public function testGetUserIdsWithTokens(): void {
+    $this->userData->method('get')
+      ->with('acquia_id', NULL, 'acquia_id_access_token')
+      ->willReturn([1 => 'data1', 5 => 'data2', 12 => 'data3']);
+
+    $this->assertSame([1, 5, 12], $this->repository->getUserIdsWithTokens());
+  }
+
+}

--- a/docroot/modules/custom/acquia_id/tests/src/Unit/OAuth2/LogoutResponseGeneratorTest.php
+++ b/docroot/modules/custom/acquia_id/tests/src/Unit/OAuth2/LogoutResponseGeneratorTest.php
@@ -6,9 +6,11 @@ namespace Drupal\Tests\acquia_id\Unit\OAuth2;
 
 use Drupal\acquia_id\OAuth2\AccessTokenRepository;
 use Drupal\acquia_id\OAuth2\LogoutResponseGenerator;
+use Drupal\acquia_id\OAuth2\ProviderFactory;
+use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Tests\UnitTestCase;
-use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
+use Drupal\user\UserDataInterface;
 use League\OAuth2\Client\Token\AccessToken;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
@@ -19,6 +21,8 @@ class LogoutResponseGeneratorTest extends UnitTestCase {
 
   private const IDP_BASE_URI = 'https://id.acquia.com/oauth2/default';
   private const LOGOUT_REDIRECT_URI = 'https://cloud.acquia.com';
+  private const USER_ID = 42;
+  private const STORAGE_KEY = 'acquia_id_access_token';
 
   public function testRedirectsThroughIdpLogoutWhenTokenHasIdToken(): void {
     $token = new AccessToken([
@@ -27,17 +31,12 @@ class LogoutResponseGeneratorTest extends UnitTestCase {
       'id_token' => 'eyJhbGciOiJSUzI1NiJ9.test',
     ]);
 
-    $repository = $this->createMock(AccessTokenRepository::class);
-    $repository->method('get')->with(42)->willReturn($token);
-
-    $account = $this->createMock(AccountInterface::class);
-    $account->method('id')->willReturn(42);
-
+    $repository = $this->buildRepository($token);
     $generator = new LogoutResponseGenerator(
       self::IDP_BASE_URI,
       self::LOGOUT_REDIRECT_URI,
       $repository,
-      $account,
+      $this->buildAccount(),
     );
 
     $response = $generator->get();
@@ -58,17 +57,12 @@ class LogoutResponseGeneratorTest extends UnitTestCase {
   }
 
   public function testRedirectsToLogoutUriWhenNoTokenStored(): void {
-    $repository = $this->createMock(AccessTokenRepository::class);
-    $repository->method('get')->with(42)->willReturn(NULL);
-
-    $account = $this->createMock(AccountInterface::class);
-    $account->method('id')->willReturn(42);
-
+    $repository = $this->buildRepository(NULL);
     $generator = new LogoutResponseGenerator(
       self::IDP_BASE_URI,
       self::LOGOUT_REDIRECT_URI,
       $repository,
-      $account,
+      $this->buildAccount(),
     );
 
     $response = $generator->get();
@@ -77,25 +71,59 @@ class LogoutResponseGeneratorTest extends UnitTestCase {
     $this->assertSame(0, $response->getCacheableMetadata()->getCacheMaxAge());
   }
 
-  public function testRedirectsToLogoutUriOnIdentityProviderException(): void {
-    $repository = $this->createMock(AccessTokenRepository::class);
-    $repository->method('get')
-      ->willThrowException(new IdentityProviderException('Refresh failed', 0, ''));
-
-    $account = $this->createMock(AccountInterface::class);
-    $account->method('id')->willReturn(42);
-
+  public function testRedirectsToLogoutUriWhenRefreshTokenTtlExpired(): void {
+    // Token stored 91 minutes ago — beyond the 90-minute refresh TTL.
+    $repository = $this->buildRepository(
+      new AccessToken(['access_token' => 'tok-old', 'expires_in' => 3600]),
+      storedMinutesAgo: 91,
+    );
     $generator = new LogoutResponseGenerator(
       self::IDP_BASE_URI,
       self::LOGOUT_REDIRECT_URI,
       $repository,
-      $account,
+      $this->buildAccount(),
     );
 
     $response = $generator->get();
 
     $this->assertSame(self::LOGOUT_REDIRECT_URI, $response->getTargetUrl());
     $this->assertSame(0, $response->getCacheableMetadata()->getCacheMaxAge());
+  }
+
+  /**
+   * Builds a real AccessTokenRepository backed by mocked UserData.
+   *
+   * AccessTokenRepository is final, so it cannot be mocked directly. Instead
+   * we construct a real instance with controlled dependencies.
+   */
+  private function buildRepository(?AccessToken $token, int $storedMinutesAgo = 0): AccessTokenRepository {
+    $now = time();
+
+    $userData = $this->createMock(UserDataInterface::class);
+    if ($token === NULL) {
+      $userData->method('get')->willReturn(NULL);
+    }
+    else {
+      $userData->method('get')
+        ->with('acquia_id', self::USER_ID, self::STORAGE_KEY)
+        ->willReturn([
+          'access_token' => $token,
+          'timestamp' => $now - ($storedMinutesAgo * 60),
+        ]);
+    }
+
+    $time = $this->createMock(TimeInterface::class);
+    $time->method('getCurrentTime')->willReturn($now);
+
+    $providerFactory = $this->createMock(ProviderFactory::class);
+
+    return new AccessTokenRepository($providerFactory, $userData, $time);
+  }
+
+  private function buildAccount(): AccountInterface {
+    $account = $this->createMock(AccountInterface::class);
+    $account->method('id')->willReturn(self::USER_ID);
+    return $account;
   }
 
 }

--- a/docroot/modules/custom/acquia_id/tests/src/Unit/OAuth2/LogoutResponseGeneratorTest.php
+++ b/docroot/modules/custom/acquia_id/tests/src/Unit/OAuth2/LogoutResponseGeneratorTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\acquia_id\Unit\OAuth2;
+
+use Drupal\acquia_id\OAuth2\AccessTokenRepository;
+use Drupal\acquia_id\OAuth2\LogoutResponseGenerator;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Tests\UnitTestCase;
+use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
+use League\OAuth2\Client\Token\AccessToken;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
+#[CoversClass(LogoutResponseGenerator::class)]
+#[Group('acquia_id')]
+class LogoutResponseGeneratorTest extends UnitTestCase {
+
+  private const IDP_BASE_URI = 'https://id.acquia.com/oauth2/default';
+  private const LOGOUT_REDIRECT_URI = 'https://cloud.acquia.com';
+
+  public function testRedirectsThroughIdpLogoutWhenTokenHasIdToken(): void {
+    $token = new AccessToken([
+      'access_token' => 'tok-123',
+      'expires' => time() + 3600,
+      'id_token' => 'eyJhbGciOiJSUzI1NiJ9.test',
+    ]);
+
+    $repository = $this->createMock(AccessTokenRepository::class);
+    $repository->method('get')->with(42)->willReturn($token);
+
+    $account = $this->createMock(AccountInterface::class);
+    $account->method('id')->willReturn(42);
+
+    $generator = new LogoutResponseGenerator(
+      self::IDP_BASE_URI,
+      self::LOGOUT_REDIRECT_URI,
+      $repository,
+      $account,
+    );
+
+    $response = $generator->get();
+
+    $this->assertStringContainsString(
+      self::IDP_BASE_URI . '/v1/logout',
+      $response->getTargetUrl(),
+    );
+    $this->assertStringContainsString(
+      'id_token_hint=eyJhbGciOiJSUzI1NiJ9.test',
+      $response->getTargetUrl(),
+    );
+    $this->assertStringContainsString(
+      'post_logout_redirect_uri=' . self::LOGOUT_REDIRECT_URI,
+      $response->getTargetUrl(),
+    );
+    $this->assertSame(0, $response->getCacheableMetadata()->getCacheMaxAge());
+  }
+
+  public function testRedirectsToLogoutUriWhenNoTokenStored(): void {
+    $repository = $this->createMock(AccessTokenRepository::class);
+    $repository->method('get')->with(42)->willReturn(NULL);
+
+    $account = $this->createMock(AccountInterface::class);
+    $account->method('id')->willReturn(42);
+
+    $generator = new LogoutResponseGenerator(
+      self::IDP_BASE_URI,
+      self::LOGOUT_REDIRECT_URI,
+      $repository,
+      $account,
+    );
+
+    $response = $generator->get();
+
+    $this->assertSame(self::LOGOUT_REDIRECT_URI, $response->getTargetUrl());
+    $this->assertSame(0, $response->getCacheableMetadata()->getCacheMaxAge());
+  }
+
+  public function testRedirectsToLogoutUriOnIdentityProviderException(): void {
+    $repository = $this->createMock(AccessTokenRepository::class);
+    $repository->method('get')
+      ->willThrowException(new IdentityProviderException('Refresh failed', 0, ''));
+
+    $account = $this->createMock(AccountInterface::class);
+    $account->method('id')->willReturn(42);
+
+    $generator = new LogoutResponseGenerator(
+      self::IDP_BASE_URI,
+      self::LOGOUT_REDIRECT_URI,
+      $repository,
+      $account,
+    );
+
+    $response = $generator->get();
+
+    $this->assertSame(self::LOGOUT_REDIRECT_URI, $response->getTargetUrl());
+    $this->assertSame(0, $response->getCacheableMetadata()->getCacheMaxAge());
+  }
+
+}

--- a/docroot/modules/custom/acquia_id/tests/src/Unit/OAuth2/Provider/AcquiaIdProviderTest.php
+++ b/docroot/modules/custom/acquia_id/tests/src/Unit/OAuth2/Provider/AcquiaIdProviderTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\acquia_id\Unit\OAuth2\Provider;
+
+use Drupal\acquia_id\OAuth2\Provider\AcquiaIdProvider;
+use Drupal\Tests\UnitTestCase;
+use League\OAuth2\Client\Token\AccessToken;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
+#[CoversClass(AcquiaIdProvider::class)]
+#[Group('acquia_id')]
+class AcquiaIdProviderTest extends UnitTestCase {
+
+  private AcquiaIdProvider $provider;
+
+  protected function setUp(): void {
+    parent::setUp();
+    $this->provider = new AcquiaIdProvider([
+      'clientId' => 'test-client',
+      'redirectUri' => 'https://example.com/callback',
+    ]);
+    $this->provider
+      ->setIdpBaseUri('https://id.acquia.com/oauth2/default')
+      ->setCloudApiBaseUri('https://cloud.acquia.com');
+  }
+
+  public function testBaseAuthorizationUrl(): void {
+    $this->assertSame(
+      'https://id.acquia.com/oauth2/default/v1/authorize',
+      $this->provider->getBaseAuthorizationUrl(),
+    );
+  }
+
+  public function testBaseAccessTokenUrl(): void {
+    $this->assertSame(
+      'https://id.acquia.com/oauth2/default/v1/token',
+      $this->provider->getBaseAccessTokenUrl([]),
+    );
+  }
+
+  public function testResourceOwnerDetailsUrl(): void {
+    $token = new AccessToken(['access_token' => 'test', 'expires_in' => 3600]);
+    $this->assertSame(
+      'https://cloud.acquia.com/api/account',
+      $this->provider->getResourceOwnerDetailsUrl($token),
+    );
+  }
+
+  public function testAuthorizationUrlContainsExpectedScopes(): void {
+    $url = $this->provider->getAuthorizationUrl();
+    $query = parse_url($url, PHP_URL_QUERY);
+    parse_str($query, $params);
+
+    $this->assertStringContainsString('openid', $params['scope']);
+    $this->assertStringContainsString('email', $params['scope']);
+    $this->assertStringContainsString('profile', $params['scope']);
+    $this->assertStringContainsString('offline_access', $params['scope']);
+  }
+
+  public function testAuthorizationUrlIncludesPkceChallenge(): void {
+    $url = $this->provider->getAuthorizationUrl();
+    $query = parse_url($url, PHP_URL_QUERY);
+    parse_str($query, $params);
+
+    $this->assertArrayHasKey('code_challenge', $params);
+    $this->assertSame('S256', $params['code_challenge_method']);
+  }
+
+}

--- a/docroot/modules/custom/acquia_id/tests/src/Unit/OAuth2/Provider/AcquiaIdResourceOwnerTest.php
+++ b/docroot/modules/custom/acquia_id/tests/src/Unit/OAuth2/Provider/AcquiaIdResourceOwnerTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\acquia_id\Unit\OAuth2\Provider;
+
+use Drupal\acquia_id\OAuth2\Provider\AcquiaIdResourceOwner;
+use Drupal\Tests\UnitTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
+#[CoversClass(AcquiaIdResourceOwner::class)]
+#[Group('acquia_id')]
+class AcquiaIdResourceOwnerTest extends UnitTestCase {
+
+  public function testGetIdReturnsMail(): void {
+    $owner = new AcquiaIdResourceOwner([
+      'mail' => 'user@example.com',
+      'uuid' => 'abc-123',
+      'timezone' => 'America/New_York',
+    ]);
+    $this->assertSame('user@example.com', $owner->getId());
+  }
+
+  public function testToArrayReturnsFullResponse(): void {
+    $data = [
+      'mail' => 'user@example.com',
+      'uuid' => 'abc-123',
+      'timezone' => 'America/New_York',
+      'first_name' => 'Jane',
+      'last_name' => 'Doe',
+    ];
+    $owner = new AcquiaIdResourceOwner($data);
+    $this->assertSame($data, $owner->toArray());
+  }
+
+}

--- a/docroot/modules/custom/acquia_trials_id/acquia_trials_id.info.yml
+++ b/docroot/modules/custom/acquia_trials_id/acquia_trials_id.info.yml
@@ -1,0 +1,9 @@
+name: 'Acquia Trials ID'
+type: module
+description: 'Verifies Acquia Cloud application access during Acquia ID SSO login.'
+package: Acquia Trials
+core_version_requirement: ^11
+hidden: true
+dependencies:
+  - acquia_id:acquia_id
+  - drupal:user

--- a/docroot/modules/custom/acquia_trials_id/acquia_trials_id.services.yml
+++ b/docroot/modules/custom/acquia_trials_id/acquia_trials_id.services.yml
@@ -1,0 +1,13 @@
+services:
+  acquia_trials_id.cloud_api.client_factory:
+    class: Drupal\acquia_trials_id\Api\ClientFactory
+    arguments:
+      - '@http_client_factory'
+      - '%acquia_id.cloud_api_base_uri%'
+
+  Drupal\acquia_trials_id\EventSubscriber\OAuth2AuthorizationEventSubscriber:
+    arguments:
+      - '@acquia_trials_id.cloud_api.client_factory'
+      - '@entity_type.manager'
+    tags:
+      - { name: event_subscriber }

--- a/docroot/modules/custom/acquia_trials_id/composer.json
+++ b/docroot/modules/custom/acquia_trials_id/composer.json
@@ -1,0 +1,9 @@
+{
+    "name": "drupal/acquia_trials_id",
+    "type": "drupal-custom-module",
+    "description": "Verifies Acquia Cloud application access during Acquia ID SSO login.",
+    "license": "GPL-2.0-or-later",
+    "require": {
+        "acquia/drupal-environment-detector": "^1"
+    }
+}

--- a/docroot/modules/custom/acquia_trials_id/src/Api/Client.php
+++ b/docroot/modules/custom/acquia_trials_id/src/Api/Client.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\acquia_trials_id\Api;
+
+use Drupal\Component\Serialization\Json;
+use GuzzleHttp\Client as HttpClient;
+
+/**
+ * Cloud API client for application access checks.
+ *
+ * @phpstan-type ApplicationResponse array{uuid: string, name: string}
+ */
+final class Client {
+
+  public function __construct(
+    private readonly HttpClient $client,
+  ) {}
+
+  /**
+   * Gets application data by UUID.
+   *
+   * @return array<string, mixed>
+   *   The JSON decoded response.
+   *
+   * @throws \GuzzleHttp\Exception\GuzzleException
+   *   If the request fails (including 403/404 when access is denied).
+   */
+  public function getApplication(string $applicationUuid): array {
+    $response = $this->client->get("/api/applications/$applicationUuid");
+    return Json::decode((string) $response->getBody());
+  }
+
+}

--- a/docroot/modules/custom/acquia_trials_id/src/Api/ClientFactory.php
+++ b/docroot/modules/custom/acquia_trials_id/src/Api/ClientFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\acquia_trials_id\Api;
+
+use Drupal\Core\Http\ClientFactory as HttpClientFactory;
+
+final readonly class ClientFactory {
+
+  public function __construct(
+    private HttpClientFactory $httpClientFactory,
+    private string $baseUri,
+  ) {}
+
+  public function get(string $accessToken): Client {
+    return new Client($this->httpClientFactory->fromOptions([
+      'base_uri' => $this->baseUri,
+      'headers' => [
+        'Accept' => 'application/json, version=2',
+        'Authorization' => "Bearer $accessToken",
+      ],
+    ]));
+  }
+
+}

--- a/docroot/modules/custom/acquia_trials_id/src/EventSubscriber/OAuth2AuthorizationEventSubscriber.php
+++ b/docroot/modules/custom/acquia_trials_id/src/EventSubscriber/OAuth2AuthorizationEventSubscriber.php
@@ -40,7 +40,7 @@ final class OAuth2AuthorizationEventSubscriber implements EventSubscriberInterfa
    */
   public function onAuthorization(OAuth2AuthorizationEvent $event): void {
     $applicationUuid = AcquiaDrupalEnvironmentDetector::getAhApplicationUuid();
-    if ($applicationUuid === NULL) {
+    if (empty($applicationUuid)) {
       throw new AccessException('Acquia application UUID is not available.');
     }
 

--- a/docroot/modules/custom/acquia_trials_id/src/EventSubscriber/OAuth2AuthorizationEventSubscriber.php
+++ b/docroot/modules/custom/acquia_trials_id/src/EventSubscriber/OAuth2AuthorizationEventSubscriber.php
@@ -44,16 +44,14 @@ final class OAuth2AuthorizationEventSubscriber implements EventSubscriberInterfa
       throw new AccessException('Acquia application UUID is not available.');
     }
 
-    $accessToken = $event->getAccessToken();
-
     try {
-      $this->clientFactory->get($accessToken->getToken())->getApplication($applicationUuid);
+      $this->clientFactory->get($event->accessToken->getToken())->getApplication($applicationUuid);
     }
     catch (GuzzleException) {
       throw new AccessException('User does not have access to this application.');
     }
 
-    $resourceOwner = $event->getProvider()->getResourceOwner($accessToken);
+    $resourceOwner = $event->provider->getResourceOwner($event->accessToken);
     $email = $resourceOwner->getId();
 
     $user = user_load_by_mail($email);

--- a/docroot/modules/custom/acquia_trials_id/src/EventSubscriber/OAuth2AuthorizationEventSubscriber.php
+++ b/docroot/modules/custom/acquia_trials_id/src/EventSubscriber/OAuth2AuthorizationEventSubscriber.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\acquia_trials_id\EventSubscriber;
+
+use Acquia\DrupalEnvironmentDetector\AcquiaDrupalEnvironmentDetector;
+use Drupal\Core\Access\AccessException;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\acquia_id\Events\OAuth2AuthorizationEvent;
+use Drupal\acquia_trials_id\Api\ClientFactory;
+use GuzzleHttp\Exception\GuzzleException;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+final class OAuth2AuthorizationEventSubscriber implements EventSubscriberInterface {
+
+  public function __construct(
+    private readonly ClientFactory $clientFactory,
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+  ) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    return [
+      OAuth2AuthorizationEvent::class => 'onAuthorization',
+    ];
+  }
+
+  /**
+   * Verifies application access and resolves the Drupal user.
+   *
+   * @throws \Drupal\Core\Access\AccessException
+   *   If the application UUID is unavailable or the user does not have access.
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   * @throws \League\OAuth2\Client\Provider\Exception\IdentityProviderException
+   */
+  public function onAuthorization(OAuth2AuthorizationEvent $event): void {
+    $applicationUuid = AcquiaDrupalEnvironmentDetector::getAhApplicationUuid();
+    if ($applicationUuid === NULL) {
+      throw new AccessException('Acquia application UUID is not available.');
+    }
+
+    $accessToken = $event->getAccessToken();
+
+    try {
+      $this->clientFactory->get($accessToken->getToken())->getApplication($applicationUuid);
+    }
+    catch (GuzzleException) {
+      throw new AccessException('User does not have access to this application.');
+    }
+
+    $resourceOwner = $event->getProvider()->getResourceOwner($accessToken);
+    $email = $resourceOwner->getId();
+
+    $user = user_load_by_mail($email);
+    if ($user === FALSE) {
+      $user = $this->entityTypeManager->getStorage('user')->create([
+        'mail' => $email,
+        'name' => $email,
+        'status' => 1,
+      ]);
+      $user->save();
+    }
+
+    $event->setUser($user);
+  }
+
+}

--- a/docroot/modules/custom/acquia_trials_id/src/EventSubscriber/OAuth2AuthorizationEventSubscriber.php
+++ b/docroot/modules/custom/acquia_trials_id/src/EventSubscriber/OAuth2AuthorizationEventSubscriber.php
@@ -61,8 +61,10 @@ final class OAuth2AuthorizationEventSubscriber implements EventSubscriberInterfa
         'name' => $email,
         'status' => 1,
       ]);
-      $user->save();
     }
+
+    $user->addRole('administrator');
+    $user->save();
 
     $event->setUser($user);
   }

--- a/docroot/modules/custom/acquia_trials_id/src/EventSubscriber/OAuth2AuthorizationEventSubscriber.php
+++ b/docroot/modules/custom/acquia_trials_id/src/EventSubscriber/OAuth2AuthorizationEventSubscriber.php
@@ -52,6 +52,7 @@ final class OAuth2AuthorizationEventSubscriber implements EventSubscriberInterfa
     }
 
     $resourceOwner = $event->provider->getResourceOwner($event->accessToken);
+    $data = $resourceOwner->toArray();
     $email = $resourceOwner->getId();
 
     $user = user_load_by_mail($email);
@@ -63,6 +64,7 @@ final class OAuth2AuthorizationEventSubscriber implements EventSubscriberInterfa
       ]);
     }
 
+    $user->set('uuid', $data['uuid'] ?? '');
     $user->addRole('administrator');
     $user->save();
 

--- a/docroot/modules/custom/acquia_trials_id/tests/src/Kernel/EventSubscriber/OAuth2AuthorizationEventSubscriberTest.php
+++ b/docroot/modules/custom/acquia_trials_id/tests/src/Kernel/EventSubscriber/OAuth2AuthorizationEventSubscriberTest.php
@@ -18,9 +18,11 @@ use League\OAuth2\Client\Provider\ResourceOwnerInterface;
 use League\OAuth2\Client\Token\AccessToken;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 #[CoversClass(OAuth2AuthorizationEventSubscriber::class)]
 #[Group('acquia_trials_id')]
+#[RunTestsInSeparateProcesses]
 class OAuth2AuthorizationEventSubscriberTest extends KernelTestBase {
 
   use UserCreationTrait;

--- a/docroot/modules/custom/acquia_trials_id/tests/src/Kernel/EventSubscriber/OAuth2AuthorizationEventSubscriberTest.php
+++ b/docroot/modules/custom/acquia_trials_id/tests/src/Kernel/EventSubscriber/OAuth2AuthorizationEventSubscriberTest.php
@@ -7,6 +7,8 @@ namespace Drupal\Tests\acquia_trials_id\Kernel\EventSubscriber;
 use Drupal\Core\Access\AccessException;
 use Drupal\Core\DependencyInjection\ContainerBuilder;
 use Drupal\KernelTests\KernelTestBase;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder as SymfonyContainerBuilder;
 use Drupal\Tests\acquia_id\Kernel\HttpClientMiddleware\MockedCloudApiMiddleware;
 use Drupal\Tests\acquia_id\Kernel\HttpClientMiddleware\MockedIdpMiddleware;
 use Drupal\Tests\user\Traits\UserCreationTrait;
@@ -58,6 +60,15 @@ class OAuth2AuthorizationEventSubscriberTest extends KernelTestBase {
       ->addTag('http_client_middleware');
     $container->register(MockedCloudApiMiddleware::class)
       ->addTag('http_client_middleware');
+
+    // Override after AcquiaIdServiceProvider::alter() sets staging URLs.
+    $container->addCompilerPass(new class implements CompilerPassInterface {
+      public function process(SymfonyContainerBuilder $container): void {
+        $container->setParameter('acquia_id.idp_base_uri', 'https://id.acquia.com/oauth2/default');
+        $container->setParameter('acquia_id.cloud_api_base_uri', 'https://cloud.acquia.com');
+        $container->setParameter('acquia_id.idp_logout_redirect_uri', 'https://cloud.acquia.com');
+      }
+    }, priority: -200);
   }
 
   public function testThrowsWhenApplicationUuidNotAvailable(): void {

--- a/docroot/modules/custom/acquia_trials_id/tests/src/Kernel/EventSubscriber/OAuth2AuthorizationEventSubscriberTest.php
+++ b/docroot/modules/custom/acquia_trials_id/tests/src/Kernel/EventSubscriber/OAuth2AuthorizationEventSubscriberTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\acquia_trials_id\Kernel\EventSubscriber;
+
+use Drupal\Core\Access\AccessException;
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\acquia_id\Kernel\HttpClientMiddleware\MockedCloudApiMiddleware;
+use Drupal\Tests\acquia_id\Kernel\HttpClientMiddleware\MockedIdpMiddleware;
+use Drupal\Tests\user\Traits\UserCreationTrait;
+use Drupal\acquia_id\Events\OAuth2AuthorizationEvent;
+use Drupal\acquia_id\OAuth2\Provider\AcquiaIdProvider;
+use Drupal\acquia_id\OAuth2\Provider\IdpProvider;
+use Drupal\acquia_trials_id\EventSubscriber\OAuth2AuthorizationEventSubscriber;
+use League\OAuth2\Client\Provider\ResourceOwnerInterface;
+use League\OAuth2\Client\Token\AccessToken;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
+#[CoversClass(OAuth2AuthorizationEventSubscriber::class)]
+#[Group('acquia_trials_id')]
+class OAuth2AuthorizationEventSubscriberTest extends KernelTestBase {
+
+  use UserCreationTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'acquia_id',
+    'acquia_trials_id',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installSchema('user', ['users_data']);
+    $this->installConfig('system');
+    // Create uid 1.
+    $this->createUser();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function register(ContainerBuilder $container): void {
+    parent::register($container);
+    $container->register(MockedIdpMiddleware::class)
+      ->addTag('http_client_middleware');
+    $container->register(MockedCloudApiMiddleware::class)
+      ->addTag('http_client_middleware');
+  }
+
+  public function testThrowsWhenApplicationUuidNotAvailable(): void {
+    // Ensure AH_APPLICATION_UUID is not set.
+    $original = getenv('AH_APPLICATION_UUID');
+    putenv('AH_APPLICATION_UUID');
+
+    try {
+      $event = $this->createEvent('VALID_ACCESS_TOKEN');
+      $subscriber = $this->container->get(OAuth2AuthorizationEventSubscriber::class);
+      $this->expectException(AccessException::class);
+      $this->expectExceptionMessage('Acquia application UUID is not available');
+      $subscriber->onAuthorization($event);
+    }
+    finally {
+      if ($original !== FALSE) {
+        putenv("AH_APPLICATION_UUID=$original");
+      }
+    }
+  }
+
+  public function testThrowsWhenUserLacksApplicationAccess(): void {
+    putenv('AH_APPLICATION_UUID=test-app-uuid');
+
+    try {
+      $event = $this->createEvent('NO_APP_ACCESS_TOKEN');
+      $subscriber = $this->container->get(OAuth2AuthorizationEventSubscriber::class);
+      $this->expectException(AccessException::class);
+      $this->expectExceptionMessage('User does not have access to this application');
+      $subscriber->onAuthorization($event);
+    }
+    finally {
+      putenv('AH_APPLICATION_UUID');
+    }
+  }
+
+  public function testCreatesNewUserOnFirstSso(): void {
+    putenv('AH_APPLICATION_UUID=test-app-uuid');
+
+    try {
+      $event = $this->createEvent('VALID_ACCESS_TOKEN');
+      $subscriber = $this->container->get(OAuth2AuthorizationEventSubscriber::class);
+      $subscriber->onAuthorization($event);
+
+      $user = $event->getUser();
+      $this->assertNotNull($user);
+      $this->assertSame('test@example.com', $user->getEmail());
+      $this->assertSame('test@example.com', $user->getAccountName());
+      $this->assertTrue($user->isActive());
+      $this->assertTrue($user->hasRole('administrator'));
+      $this->assertSame('user-uuid-12345', $user->uuid());
+    }
+    finally {
+      putenv('AH_APPLICATION_UUID');
+    }
+  }
+
+  public function testLoadsExistingUserByEmail(): void {
+    putenv('AH_APPLICATION_UUID=test-app-uuid');
+
+    try {
+      // Create an existing user with the same email.
+      $existing = $this->createUser([], 'test@example.com', FALSE, [
+        'mail' => 'test@example.com',
+      ]);
+      $existing_uid = $existing->id();
+
+      $event = $this->createEvent('VALID_ACCESS_TOKEN');
+      $subscriber = $this->container->get(OAuth2AuthorizationEventSubscriber::class);
+      $subscriber->onAuthorization($event);
+
+      $user = $event->getUser();
+      $this->assertNotNull($user);
+      // Should be the same user, not a new one.
+      $this->assertSame($existing_uid, $user->id());
+      $this->assertSame('test@example.com', $user->getEmail());
+      $this->assertTrue($user->hasRole('administrator'));
+      $this->assertSame('user-uuid-12345', $user->uuid());
+    }
+    finally {
+      putenv('AH_APPLICATION_UUID');
+    }
+  }
+
+  /**
+   * Creates an OAuth2AuthorizationEvent with a mock provider.
+   */
+  private function createEvent(string $accessTokenValue): OAuth2AuthorizationEvent {
+    $token = new AccessToken([
+      'access_token' => $accessTokenValue,
+      'expires' => time() + 3600,
+    ]);
+
+    $provider = $this->container->get('acquia_id.oauth2.provider');
+    return new OAuth2AuthorizationEvent($provider, $token);
+  }
+
+}

--- a/docroot/modules/custom/acquia_trials_id/tests/src/Unit/Api/ClientFactoryTest.php
+++ b/docroot/modules/custom/acquia_trials_id/tests/src/Unit/Api/ClientFactoryTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\acquia_trials_id\Unit\Api;
+
+use Drupal\acquia_trials_id\Api\Client;
+use Drupal\acquia_trials_id\Api\ClientFactory;
+use Drupal\Core\Http\ClientFactory as HttpClientFactory;
+use Drupal\Tests\UnitTestCase;
+use GuzzleHttp\Client as HttpClient;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
+#[CoversClass(ClientFactory::class)]
+#[Group('acquia_trials_id')]
+class ClientFactoryTest extends UnitTestCase {
+
+  public function testGetReturnsClientWithCorrectConfiguration(): void {
+    $httpClient = $this->createMock(HttpClient::class);
+
+    $httpClientFactory = $this->createMock(HttpClientFactory::class);
+    $httpClientFactory->expects($this->once())
+      ->method('fromOptions')
+      ->with([
+        'base_uri' => 'https://cloud.acquia.com',
+        'headers' => [
+          'Accept' => 'application/json, version=2',
+          'Authorization' => 'Bearer test-token-xyz',
+        ],
+      ])
+      ->willReturn($httpClient);
+
+    $factory = new ClientFactory($httpClientFactory, 'https://cloud.acquia.com');
+    $client = $factory->get('test-token-xyz');
+
+    $this->assertInstanceOf(Client::class, $client);
+  }
+
+}

--- a/docroot/modules/custom/acquia_trials_id/tests/src/Unit/Api/ClientTest.php
+++ b/docroot/modules/custom/acquia_trials_id/tests/src/Unit/Api/ClientTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\acquia_trials_id\Unit\Api;
+
+use Drupal\acquia_trials_id\Api\Client;
+use Drupal\Tests\UnitTestCase;
+use GuzzleHttp\Client as HttpClient;
+use GuzzleHttp\Exception\ClientException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+
+#[CoversClass(Client::class)]
+#[Group('acquia_trials_id')]
+class ClientTest extends UnitTestCase {
+
+  public function testGetApplicationReturnsDecodedResponse(): void {
+    $responseData = ['uuid' => 'app-uuid-123', 'name' => 'My App'];
+
+    $body = $this->createMock(StreamInterface::class);
+    $body->method('__toString')->willReturn(json_encode($responseData));
+
+    $response = $this->createMock(ResponseInterface::class);
+    $response->method('getBody')->willReturn($body);
+
+    $httpClient = $this->createMock(HttpClient::class);
+    $httpClient->expects($this->once())
+      ->method('get')
+      ->with('/api/applications/app-uuid-123')
+      ->willReturn($response);
+
+    $client = new Client($httpClient);
+    $result = $client->getApplication('app-uuid-123');
+
+    $this->assertSame($responseData, $result);
+  }
+
+  public function testGetApplicationThrowsOnHttpError(): void {
+    $httpClient = $this->createMock(HttpClient::class);
+    $httpClient->method('get')
+      ->willThrowException(new ClientException(
+        'Forbidden',
+        $this->createMock(RequestInterface::class),
+        $this->createMock(ResponseInterface::class),
+      ));
+
+    $client = new Client($httpClient);
+
+    $this->expectException(ClientException::class);
+    $client->getApplication('no-access-uuid');
+  }
+
+}

--- a/recipes/custom/acquia_trials/recipe.yml
+++ b/recipes/custom/acquia_trials/recipe.yml
@@ -5,6 +5,7 @@ install:
   - acquia_trials_countdown
   - acquia_trials_checklist
   - acquia_trials_cloud_platform
+  - acquia_trials_id
 config:
   strict: false
   actions:


### PR DESCRIPTION
## Summary

- Adds `acquia_id` — a standalone OAuth2 SSO module using the PKCE authorization code flow against Acquia ID (`id.acquia.com`). Dispatches `OAuth2AuthorizationEvent` for subscriber-based user resolution; ships with no default subscriber so implementing modules control user find/create logic.
- Adds `acquia_trials_id` — a thin module that subscribes to `OAuth2AuthorizationEvent`, verifies the authenticated user has access to the current Acquia Cloud application via `GET /api/applications/{uuid}`, then finds or creates the Drupal user by email.
- Adds `league/oauth2-client: ^2` to the root `composer.json`.

## Key design decisions

- `CLIENT_ID` is a service parameter (`acquia_id.client_id`) rather than a hardcoded constant, making it overridable per environment.
- The legacy `accounts.acquia.com` Acquia provider is not included; only the modern Acquia ID (`id.acquia.com`) provider is used.
- SSO route is `/acquia-id/sso` (route name `acquia_id.sso`).
- `acquia_trials_id` reuses `%acquia_id.cloud_api_base_uri%` and reads the application UUID from `AcquiaDrupalEnvironmentDetector::getAhApplicationUuid()`.

## Test plan

- [ ] Configure `acquia_id.*` service parameters and enable `acquia_id`
- [ ] Visit `/acquia-id/sso` — should redirect to Acquia ID authorization URL
- [ ] Complete OAuth flow — `OAuth2AuthorizationEvent` should be dispatched
- [ ] Enable `acquia_trials_id` and confirm login grants access when the Cloud API returns 200 for the application UUID
- [ ] Confirm login is denied (redirects to `idp_logout_redirect_uri`) when the Cloud API returns a non-200

🤖 Generated with [Claude Code](https://claude.com/claude-code)