### PR TITLE
Add Pulse site template back

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
         "drupal/healthcare": "^1.0",
         "drupal/local": "^1.0",
         "drupal/provus_edu": "^1.0",
+        "drupal/pulse": "^1.0",
         "drupal/recipe_installer_kit": "^1.0.4",
         "drupal/webform": "@beta"
     },

--- a/docroot/sites/default/site-templates.php
+++ b/docroot/sites/default/site-templates.php
@@ -71,6 +71,19 @@ return [
     ],
     'creator' => 'Kanopi Studios',
   ],
+  'pulse' => [
+    'name' => 'Pulse',
+    'description' => 'Designed for a modern health and wellness platform. Features sections for health topics, research studies, expert insights, articles, and reviews. Supports FAQs, trending content, and expert consultation forms.',
+    'screenshot' => 'https://git.drupalcode.org/project/pulse/-/raw/1.0.x/screenshot.webp?ref_type=heads',
+    'package' => 'drupal/pulse',
+    'links' => [
+      [
+        'text' => 'Learn more',
+        'url' => 'https://new.drupal.org/site-template/pulse-healthcare',
+      ],
+    ],
+    'creator' => 'QED42',
+  ],
   'local' => [
     'name' => 'Local',
     'description' => 'A local council website with services, navigation, and demo content in a classic blue and white palette.',


### PR DESCRIPTION
Reverts the removal in 7780cf3 ("Remove pulse (#35)").

**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
We should add Pulse back in once it starts passing tests.

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->
Run CI. If Pulse passes tests, it's ready to be merged back in.
