### PR TITLE
Don't export config in dist branch

### DIFF
--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -81,8 +81,6 @@ jobs:
             --account-pass=admin \
             --yes
 
-          ./vendor/bin/drush config:export --generic --yes
-
       - name: Remove values that should be unique.
         run: |
           cd $ARTIFACT_DIR
@@ -121,16 +119,6 @@ jobs:
           git add -A
           git commit -m "Build artifact from ${{ github.sha }}"
           git push --force "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git" HEAD:dist
-
-      - name: Checkout dist branch
-        uses: actions/checkout@v4
-        with:
-          ref: dist
-
-      - name: Install from dist config
-        run: |
-          ./vendor/bin/drush drupal:hash-salt:init
-          ./vendor/bin/drush site:install --existing-config
 
       - name: Summary
         run: |


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Now that we offer many site templates, we no longer install from exported config. So we can remove the Action that generates and exports it.

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
The dist branch will no longer contain exported config.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->
We could build multiple dist branches, one for each site template. But installing from config was never ideal. The main reason we did it was it was faster than running through the Drupal CMS Installer, but that's no longer the case now that we're pulling in the patch from #3498026.

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->
The dist branch should no longer contain exported config.
