### PR TITLE
Calculate trial expiry

### DIFF
--- a/docroot/modules/custom/acquia_trials_countdown/acquia_trials_countdown.install
+++ b/docroot/modules/custom/acquia_trials_countdown/acquia_trials_countdown.install
@@ -9,9 +9,11 @@
  * Implements hook_install().
  */
 function acquia_trials_countdown_install() {
-  $subscription_id = getenv('SUBSCRIPTION_ID') ?: '';
-  $trial_end = \Drupal::service('acquia_trials_countdown.trial_end_client')
-    ->fetchTrialEnd($subscription_id);
+  // @todo Use the API to get expiration when it's ready.
+  //$subscription_id = getenv('SUBSCRIPTION_ID') ?: '';
+  //$trial_end = \Drupal::service('acquia_trials_countdown.trial_end_client')
+  //  ->fetchTrialEnd($subscription_id);
+  $trial_end = (60 * 60 * 24 * 14) + time();
   \Drupal::state()->set('acquia_trials_countdown.trial_end', $trial_end);
 }
 

--- a/docroot/modules/custom/acquia_trials_countdown/acquia_trials_countdown.module
+++ b/docroot/modules/custom/acquia_trials_countdown/acquia_trials_countdown.module
@@ -21,8 +21,9 @@ function acquia_trials_countdown_fetch_trial_end(): int {
  * Implements hook_cron().
  */
 function acquia_trials_countdown_cron() {
-  $trial_end = acquia_trials_countdown_fetch_trial_end();
-  \Drupal::state()->set('acquia_trials_countdown.trial_end', $trial_end);
+  // @todo reenable once the API is ready.
+  //$trial_end = acquia_trials_countdown_fetch_trial_end();
+  //\Drupal::state()->set('acquia_trials_countdown.trial_end', $trial_end);
 }
 
 /**


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Rather than ask an API when the site expires, we can just calculate it on module install time.

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
This hard-codes the trial expiry for 14 days from the time it was installed. It also removes automatically updating that time on cron.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->
Wait for the API to be ready.

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->
Upon installation of the `acquia_trials_countdown` module, the banner should read "13 days left in your trial" (Not "14" as slightly less than 14 days will be left immediately after installation)
