### PR TITLE
ONR-135 | Add IdpUrls and CloudApiUrls helpers for env URL determination

### DIFF
--- a/docroot/modules/custom/acquia_id/src/Controller/OAuth2Controller.php
+++ b/docroot/modules/custom/acquia_id/src/Controller/OAuth2Controller.php
@@ -80,7 +80,7 @@ final class OAuth2Controller implements ContainerInjectionInterface {
       // Use AH_APPLICATION_UUID from environment for environment selection.
       $uuid = getenv('AH_APPLICATION_UUID') ?: '';
       $idpUrl = AcquiaEnvironmentUrls::getIdpUrl($uuid, $this->cloudApiChecker);
-      $this->provider->setBaseAuthorizationUrl($idpUrl);
+      $this->provider->setIdpBaseUri($idpUrl);
       $response = new TrustedRedirectResponse(
         $this->provider->getAuthorizationUrl(),
         Response::HTTP_SEE_OTHER

--- a/docroot/modules/custom/acquia_id/src/Controller/OAuth2Controller.php
+++ b/docroot/modules/custom/acquia_id/src/Controller/OAuth2Controller.php
@@ -15,6 +15,8 @@ use Drupal\Core\Url;
 use Drupal\acquia_id\Events\OAuth2AuthorizationEvent;
 use Drupal\acquia_id\OAuth2\AccessTokenRepository;
 use Drupal\acquia_id\OAuth2\Provider\AcquiaIdProvider;
+use Drupal\acquia_id\Helper\AcquiaEnvironmentUrls;
+use Drupal\acquia_id\Helper\CloudApiChecker;
 use GuzzleHttp\Exception\RequestException;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use League\OAuth2\Client\Token\AccessToken;
@@ -40,6 +42,7 @@ final class OAuth2Controller implements ContainerInjectionInterface {
     private readonly EventDispatcherInterface $eventDispatcher,
     private readonly AccessTokenRepository $accessTokenRepository,
     private readonly string $idpLogoutRedirectUri,
+    private readonly CloudApiChecker $cloudApiChecker,
   ) {
   }
 
@@ -53,6 +56,7 @@ final class OAuth2Controller implements ContainerInjectionInterface {
       $container->get('event_dispatcher'),
       $container->get('acquia_id.oauth2.access_token_repository'),
       $container->getParameter('acquia_id.idp_logout_redirect_uri'),
+      new CloudApiChecker(),
     );
   }
 
@@ -73,6 +77,10 @@ final class OAuth2Controller implements ContainerInjectionInterface {
         $this->session->set('oauth2_destination', $request->query->get('destination'));
         $request->query->set('destination', '');
       }
+      // Use AH_APPLICATION_UUID from environment for environment selection.
+      $uuid = getenv('AH_APPLICATION_UUID') ?: '';
+      $idpUrl = AcquiaEnvironmentUrls::getIdpUrl($uuid, $this->cloudApiChecker);
+      $this->provider->setBaseAuthorizationUrl($idpUrl);
       $response = new TrustedRedirectResponse(
         $this->provider->getAuthorizationUrl(),
         Response::HTTP_SEE_OTHER

--- a/docroot/modules/custom/acquia_id/src/Helper/AcquiaEnvironmentUrls.php
+++ b/docroot/modules/custom/acquia_id/src/Helper/AcquiaEnvironmentUrls.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\acquia_id\Helper;
+
+/**
+ * Helper for determining Acquia environment URLs based on UUID presence.
+ */
+final class AcquiaEnvironmentUrls {
+
+  /**
+   * Returns the correct Acquia ID URL based on UUID presence in prod.
+   *
+   * @param string $uuid
+   *   The application or environment UUID.
+   * @param callable $cloudApiChecker
+   *   A callable that checks if the UUID exists in prod (returns bool).
+   *
+   * @return string
+   *   The Acquia ID URL (prod or staging).
+   */
+  public static function getIdpUrl(string $uuid, callable $cloudApiChecker): string {
+    if ($cloudApiChecker($uuid)) {
+      return 'https://id.acquia.com';
+    }
+    return 'https://staging.id.acquia.com';
+  }
+
+  /**
+   * Returns the correct Acquia Cloud URL based on UUID presence in prod.
+   *
+   * @param string $uuid
+   *   The application or environment UUID.
+   * @param callable $cloudApiChecker
+   *   A callable that checks if the UUID exists in prod (returns bool).
+   *
+   * @return string
+   *   The Acquia Cloud URL (prod or staging).
+   */
+  public static function getCloudUrl(string $uuid, callable $cloudApiChecker): string {
+    if ($cloudApiChecker($uuid)) {
+      return 'https://cloud.acquia.com';
+    }
+    return 'https://staging.cloud.acquia.com';
+  }
+
+}

--- a/docroot/modules/custom/acquia_id/src/Helper/CloudApiChecker.php
+++ b/docroot/modules/custom/acquia_id/src/Helper/CloudApiChecker.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\acquia_id\Helper;
+
+/**
+ * Helper for checking UUID presence in prod Cloud UI.
+ */
+final class CloudApiChecker {
+  /**
+   * Checks if the given UUID exists in prod Cloud UI.
+   * Replace this stub with actual API logic.
+   *
+   * @param string $uuid
+   *   The application or environment UUID.
+   *
+   * @return bool
+   *   TRUE if exists in prod, FALSE otherwise.
+   */
+  public function __invoke(string $uuid): bool {
+    // TODO: Implement actual Cloud API check here.
+    // Example: return $this->cloudApiClient->uuidExistsInProd($uuid);
+    return false;
+  }
+}


### PR DESCRIPTION
**Motivation**
SSO not working for any gardens environment.
Probable reason - 
The code attempted to call a non-existent method (setBaseAuthorizationUrl()), so the provider's base URL was never set dynamically. This means the OAuth2 flow would always use the default or hardcoded IdP URL, which would not work for different environments (dev, stage, prod, etc.) that require environment-specific IdP endpoints.

**Proposed changes**

- In addition to above method not existing, `AH_SITE_ENVIRONMENT` won't be the correct env variable to determine staging vs prod URLs.
- Reason -  All dev, test, prod envs are created for 1 application. So all are present as part of single Acquia ID staging account.
- We will need to check if `AH_APPLICATION_UUID` is staging or prod application and then determine URLs

**Testing steps**
Pending


