### PR TITLE
Use prod SSO domains unless on gardens

### DIFF
--- a/docroot/modules/custom/acquia_id/src/AcquiaIdServiceProvider.php
+++ b/docroot/modules/custom/acquia_id/src/AcquiaIdServiceProvider.php
@@ -13,13 +13,13 @@ final class AcquiaIdServiceProvider extends ServiceProviderBase {
   public function alter(ContainerBuilder $container): void {
     parent::alter($container);
 
-    if (EnvironmentDetector::isProdEnv()) {
-      $idp_base_uri = 'https://id.acquia.com/oauth2/default';
-      $cloud_api_base_uri = 'https://cloud.acquia.com';
-    }
-    else {
+    if (EnvironmentDetector::getAhRealm() === 'gardens') {
       $idp_base_uri = 'https://staging.id.acquia.com/oauth2/default';
       $cloud_api_base_uri = 'https://staging.cloud.acquia.com';
+    }
+    else {
+      $idp_base_uri = 'https://id.acquia.com/oauth2/default';
+      $cloud_api_base_uri = 'https://cloud.acquia.com';
     }
 
     $container->setParameter('acquia_id.idp_base_uri', $idp_base_uri);


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Logic for SSO domains is incorrect

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
This changes what attributes we use to deduce environment (use realm) and changes the default to prod URLs (only uses staging URLs in gardens)
