### PR TITLE
Only show countdown banned to admin users

### DIFF
--- a/docroot/modules/custom/acquia_trials_countdown/acquia_trials_countdown.module
+++ b/docroot/modules/custom/acquia_trials_countdown/acquia_trials_countdown.module
@@ -30,6 +30,10 @@ function acquia_trials_countdown_cron() {
  * Implements hook_page_attachments().
  */
 function acquia_trials_countdown_page_attachments(array &$attachments) {
+  if (!\Drupal::currentUser()->hasPermission('access administration pages')) {
+    return;
+  }
+
   $trial_end = \Drupal::state()->get('acquia_trials_countdown.trial_end');
 
   $attachments['#attached']['library'][] = 'acquia_trials_countdown/countdown-banner';

--- a/docroot/modules/custom/acquia_trials_countdown/acquia_trials_countdown.module
+++ b/docroot/modules/custom/acquia_trials_countdown/acquia_trials_countdown.module
@@ -30,6 +30,7 @@ function acquia_trials_countdown_cron() {
  * Implements hook_page_attachments().
  */
 function acquia_trials_countdown_page_attachments(array &$attachments) {
+  $attachments['#cache']['contexts'][] = 'user.permissions';
   if (!\Drupal::currentUser()->hasPermission('access administration pages')) {
     return;
   }


### PR DESCRIPTION
Currently, the countdown banner is showed on all pages to all users. This PR changes that behavior such that it is displayed on all pages, but only for authenticated users that have the "view administration pages" permission.