### PR TITLE
ONR-205 | Use prod Cloud uri unless on gardens

### DIFF
--- a/docroot/modules/custom/acquia_trials_cloud_platform/src/Plugin/Block/TrialsCloudPlatformBlock.php
+++ b/docroot/modules/custom/acquia_trials_cloud_platform/src/Plugin/Block/TrialsCloudPlatformBlock.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\acquia_trials_cloud_platform\Plugin\Block;
 
+use Acquia\Drupal\RecommendedSettings\Helpers\EnvironmentDetector;
 use Drupal\Core\Block\Attribute\Block;
 use Drupal\Core\Block\BlockBase;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
@@ -38,10 +39,14 @@ class TrialsCloudPlatformBlock extends BlockBase {
       ],
     ];
 
+    $cloud_api_base_uri = EnvironmentDetector::getAhRealm() === 'gardens'
+      ? 'https://staging.cloud.acquia.com'
+      : 'https://cloud.acquia.com';
+
     $subscription_id = getenv('AH_APPLICATION_UUID') ?: '';
     $cta_url = $subscription_id !== ''
-      ? 'https://cloud.acquia.com/a/applications/' . $subscription_id
-      : 'https://cloud.acquia.com';
+      ? $cloud_api_base_uri . '/a/applications/' . $subscription_id
+      : $cloud_api_base_uri;
 
     return [
       '#theme' => 'acquia_trials_cloud_platform',

--- a/docroot/modules/custom/acquia_trials_cloud_platform/src/Plugin/Block/TrialsCloudPlatformBlock.php
+++ b/docroot/modules/custom/acquia_trials_cloud_platform/src/Plugin/Block/TrialsCloudPlatformBlock.php
@@ -44,14 +44,10 @@ class TrialsCloudPlatformBlock extends BlockBase {
       : 'https://cloud.acquia.com';
 
     $subscription_id = getenv('AH_APPLICATION_UUID') ?: '';
-    $cta_url = $subscription_id !== ''
-      ? $cloud_api_base_uri . '/a/applications/' . $subscription_id
-      : $cloud_api_base_uri;
-
     return [
       '#theme' => 'acquia_trials_cloud_platform',
       '#features' => $features,
-      '#cta_url' => $cta_url,
+      '#cta_url' => $cloud_api_base_uri . '/a/applications/' . $subscription_id,
       '#attached' => [
         'library' => ['acquia_trials_cloud_platform/cloud-platform'],
       ],


### PR DESCRIPTION
**Motivation**
Ticket - https://acquia.atlassian.net/browse/ONR-205

Root cause identified: 

- The 'Go to Cloud Platform' button on the Gardens (staging) Drupal CMS site is hardcoded to point to Prod Cloud UI and Prod Acquia ID. 
- It should point to Staging Cloud UI and Staging Acquia ID when running in a non-production environment. 
- This is an env config issue — will not affect production users. 

**Proposed changes**
Fix: make the Cloud Platform URL environment-aware.