### PR TITLE
Change logic per ONR-242

### DIFF
--- a/docroot/modules/custom/acquia_trials_countdown/js/acquia_trials_countdown.js
+++ b/docroot/modules/custom/acquia_trials_countdown/js/acquia_trials_countdown.js
@@ -27,16 +27,11 @@
   }
 
   function formatTimeLeft(seconds) {
-    var days = Math.floor(seconds / 86400);
+    var days = Math.ceil(seconds / 86400);
     if (days >= 1) {
       return days + (days === 1 ? ' day' : ' days') + ' left in your trial.';
     }
-    var hours = Math.floor(seconds / 3600);
-    if (hours >= 1) {
-      return hours + (hours === 1 ? ' hour' : ' hours') + ' left in your trial.';
-    }
-    var minutes = Math.max(1, Math.floor(seconds / 60));
-    return minutes + (minutes === 1 ? ' minute' : ' minutes') + ' left in your trial.';
+    return 'Expires today.';
   }
 
   function createBanner() {

--- a/docroot/modules/custom/acquia_trials_countdown/js/acquia_trials_countdown.js
+++ b/docroot/modules/custom/acquia_trials_countdown/js/acquia_trials_countdown.js
@@ -28,8 +28,8 @@
 
   function formatTimeLeft(seconds) {
     var days = Math.ceil(seconds / 86400);
-    if (days >= 1) {
-      return days + (days === 1 ? ' day' : ' days') + ' left in your trial.';
+    if (days > 1) {
+      return days + ' days left in your trial.';
     }
     return 'Expires today.';
   }


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Standardizes the logic behind converting a timestamp to human readable time left.

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->
New behavior:
* expiry = 13d 23h 30m. Message 14 days left in your trial.
* expiry = 13d 1h 30m. Message 14 days left in your trial.
* expiry = 0d 23h 30m. Message Expires today.
* expiry = 0d 0h 30m. Message Expires today.
