### PR TITLE
Allow authenticted users to view sso login page

### DIFF
--- a/docroot/modules/custom/acquia_id/src/Controller/OAuth2Controller.php
+++ b/docroot/modules/custom/acquia_id/src/Controller/OAuth2Controller.php
@@ -62,7 +62,8 @@ final class OAuth2Controller implements ContainerInjectionInterface {
    * @link https://oauth.net/2/pkce/
    */
   public function __invoke(Request $request): RedirectResponse|array {
-    if (!$this->currentUser->isAnonymous()) {
+    $isCallback = $request->query->has('code') || $request->query->has('state') || $request->query->has('error');
+    if (!$isCallback && !$this->currentUser->isAnonymous()) {
       $token = NULL;
       try {
         $token = $this->accessTokenRepository->get((int) $this->currentUser->id());
@@ -71,9 +72,11 @@ final class OAuth2Controller implements ContainerInjectionInterface {
       }
       if ($token !== NULL) {
         $destination = $request->query->get('destination', '');
-        $url = $destination ? Url::fromUserInput($destination) : Url::fromRoute('<front>');
+        if ($destination) {
+          return new RedirectResponse(Url::fromUserInput($destination)->toString(), Response::HTTP_SEE_OTHER);
+        }
         return [
-          '#markup' => '<p>' . $this->t('You are already logged in.') . '</p><p><a href="' . $url->toString() . '">' . $this->t('Continue') . '</a></p>',
+          '#markup' => '<p>' . $this->t('You are already logged in.') . '</p><p><a href="' . Url::fromRoute('<front>')->toString() . '">' . $this->t('Continue') . '</a></p>',
         ];
       }
     }

--- a/docroot/modules/custom/acquia_id/src/Controller/OAuth2Controller.php
+++ b/docroot/modules/custom/acquia_id/src/Controller/OAuth2Controller.php
@@ -15,8 +15,6 @@ use Drupal\Core\Url;
 use Drupal\acquia_id\Events\OAuth2AuthorizationEvent;
 use Drupal\acquia_id\OAuth2\AccessTokenRepository;
 use Drupal\acquia_id\OAuth2\Provider\AcquiaIdProvider;
-use GuzzleHttp\Exception\RequestException;
-use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use League\OAuth2\Client\Token\AccessToken;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -40,6 +38,7 @@ final class OAuth2Controller implements ContainerInjectionInterface {
     private readonly EventDispatcherInterface $eventDispatcher,
     private readonly AccessTokenRepository $accessTokenRepository,
     private readonly string $idpLogoutRedirectUri,
+    private readonly AccountInterface $currentUser,
   ) {
   }
 
@@ -53,6 +52,7 @@ final class OAuth2Controller implements ContainerInjectionInterface {
       $container->get('event_dispatcher'),
       $container->get('acquia_id.oauth2.access_token_repository'),
       $container->getParameter('acquia_id.idp_logout_redirect_uri'),
+      $container->get('current_user'),
     );
   }
 
@@ -61,7 +61,23 @@ final class OAuth2Controller implements ContainerInjectionInterface {
    *
    * @link https://oauth.net/2/pkce/
    */
-  public function __invoke(Request $request): RedirectResponse {
+  public function __invoke(Request $request): RedirectResponse|array {
+    if (!$this->currentUser->isAnonymous()) {
+      $token = NULL;
+      try {
+        $token = $this->accessTokenRepository->get((int) $this->currentUser->id());
+      }
+      catch (\Exception) {
+      }
+      if ($token !== NULL) {
+        $destination = $request->query->get('destination', '');
+        $url = $destination ? Url::fromUserInput($destination) : Url::fromRoute('<front>');
+        return [
+          '#markup' => '<p>' . $this->t('You are already logged in.') . '</p><p><a href="' . $url->toString() . '">' . $this->t('Continue') . '</a></p>',
+        ];
+      }
+    }
+
     // Check if this is a subrequest being made on access denied exception.
     // @see \Drupal\Core\EventSubscriber\HttpExceptionSubscriberBase::onException().
     if ($request->attributes->has('exception')) {
@@ -135,17 +151,7 @@ final class OAuth2Controller implements ContainerInjectionInterface {
    * Checks access for the SSO route.
    */
   public function access(AccountInterface $account): AccessResultInterface {
-    $token = NULL;
-    try {
-      $token = $this->accessTokenRepository->get((int) $account->id());
-    }
-    catch (IdentityProviderException) {
-      return AccessResult::allowed();
-    }
-    catch (RequestException) {
-    }
-
-    return AccessResult::allowedIf($account->isAnonymous() || $token === NULL);
+    return AccessResult::allowed();
   }
 
   private function accessDeniedRedirect(string $logMessage = 'Access denied'): RedirectResponse {

--- a/docroot/modules/custom/acquia_id/tests/src/Kernel/Controller/OAuth2ControllerTest.php
+++ b/docroot/modules/custom/acquia_id/tests/src/Kernel/Controller/OAuth2ControllerTest.php
@@ -192,7 +192,7 @@ class OAuth2ControllerTest extends KernelTestBase {
     $this->assertTrue($result);
   }
 
-  public function testSsoRouteAccessAuthenticatedWithTokenDenied(): void {
+  public function testSsoRouteAccessAuthenticatedWithToken(): void {
     $access_manager = $this->container->get('access_manager');
     $user = $this->setUpCurrentUser();
 
@@ -208,7 +208,7 @@ class OAuth2ControllerTest extends KernelTestBase {
       ]);
 
     $result = $access_manager->checkNamedRoute('acquia_id.sso', [], $user);
-    $this->assertFalse($result);
+    $this->assertTrue($result);
   }
 
   /**

--- a/docroot/modules/custom/acquia_id/tests/src/Kernel/Controller/OAuth2ControllerTest.php
+++ b/docroot/modules/custom/acquia_id/tests/src/Kernel/Controller/OAuth2ControllerTest.php
@@ -211,6 +211,51 @@ class OAuth2ControllerTest extends KernelTestBase {
     $this->assertTrue($result);
   }
 
+  public function testAuthenticatedWithTokenShowsAlreadyLoggedIn(): void {
+    $user = $this->setUpCurrentUser();
+
+    $token = new AccessToken([
+      'access_token' => 'VALID_ACCESS_TOKEN',
+      'expires' => time() + 3600,
+    ]);
+    $this->container->get('user.data')
+      ->set('acquia_id', $user->id(), 'acquia_id_access_token', [
+        'access_token' => $token,
+        'timestamp' => time(),
+      ]);
+
+    $response = $this->doRequest(
+      Request::create(Url::fromRoute('acquia_id.sso')->toString()),
+    );
+
+    $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+    $this->assertStringContainsString('You are already logged in.', $response->getContent());
+    $this->assertStringContainsString('Continue', $response->getContent());
+  }
+
+  public function testAuthenticatedWithTokenAndDestinationRedirects(): void {
+    $user = $this->setUpCurrentUser();
+
+    $token = new AccessToken([
+      'access_token' => 'VALID_ACCESS_TOKEN',
+      'expires' => time() + 3600,
+    ]);
+    $this->container->get('user.data')
+      ->set('acquia_id', $user->id(), 'acquia_id_access_token', [
+        'access_token' => $token,
+        'timestamp' => time(),
+      ]);
+
+    $response = $this->doRequest(
+      Request::create(Url::fromRoute('acquia_id.sso', [], [
+        'query' => ['destination' => '/admin'],
+      ])->toString()),
+    );
+
+    $this->assertSame(Response::HTTP_SEE_OTHER, $response->getStatusCode());
+    $this->assertStringContainsString('/admin', $response->headers->get('Location'));
+  }
+
   /**
    * Makes an HTTP request through the kernel.
    */


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Trials links to /acquia-id/sso. But once a user is logged in and has a token, that route will return a 403. This was by design and mimics the behavior of the `/user/login` route from core. But given that Trials links directly to it, we should account for it.

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->


**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->
In HaaS, the user is linked to an edit page and redirected to login if they're not. So we could do that. But since this is supposed to be a more general solution, I think it makes sense to handle people who arrive on `acquia-id/sso` more gracefully.

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->
Current behavior:
1. Open a browser and navigate to: <DRUPAL_CMS_TRIAL_URL>/acquia-id/sso?destination=/admin/dashboard
2. Observe that the first visit succeeds — user is redirected to /admin/dashboard
3. Navigate to the same URL again: <DRUPAL_CMS_TRIAL_URL>/acquia-id/sso?destination=/admin/dashboard in new tab
4. Observe: Access Denied error is returned on the second request

New behavior:
1. Open a browser and navigate to: <DRUPAL_CMS_TRIAL_URL>/acquia-id/sso?destination=/admin/dashboard
2. Observe that the first visit succeeds — user is redirected to /admin/dashboard
3. Navigate to the same URL again: <DRUPAL_CMS_TRIAL_URL>/acquia-id/sso?destination=/admin/dashboard in new tab
4. Observe: User is redirected to /admin/dashboard
5. Navigate to: <DRUPAL_CMS_TRIAL_URL>/acquia-id/sso (no destination param)
6. User is shown a message indicating they are already logged in with a link to the frontpage.