### PR TITLE
Suppress README files from core scaffold

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -93,7 +93,11 @@
                     "mode": "replace",
                     "overwrite": false,
                     "path": "docroot/core/assets/scaffold/files/default.settings.php"
-                }
+                },
+                "[project-root]/recipes/README.txt": false,
+                "[web-root]/modules/README.txt": false,
+                "[web-root]/profiles/README.txt": false,
+                "[web-root]/themes/README.txt": false
             }
         },
         "installer-paths": {

--- a/composer.json
+++ b/composer.json
@@ -97,7 +97,11 @@
                 "[project-root]/recipes/README.txt": false,
                 "[web-root]/modules/README.txt": false,
                 "[web-root]/profiles/README.txt": false,
-                "[web-root]/themes/README.txt": false
+                "[web-root]/themes/README.txt": false,
+                "[web-root]/sites/README.txt": false,
+                "[web-root]/sites/development.services.yml": false,
+                "[web-root]/sites/example.settings.local.php": false,
+                "[web-root]/sites/example.sites.php": false
             }
         },
         "installer-paths": {


### PR DESCRIPTION
**Motivation**
There are unnecessary README.txt files in certain directories, scaffolded in by core. We can suppress these by overriding scaffold configuration.

**Proposed changes**
Suppresses the unnecessary files.