### PR TITLE
Add acquia_disable_package_manager

### DIFF
--- a/docroot/modules/custom/acquia_disable_package_manager/acquia_disable_package_manager.info.yml
+++ b/docroot/modules/custom/acquia_disable_package_manager/acquia_disable_package_manager.info.yml
@@ -1,0 +1,5 @@
+name: 'Disable Package Manager'
+type: module
+description: 'Disables Package Manager operations on Acquia hosting.'
+hidden: true
+core_version_requirement: ^11

--- a/docroot/modules/custom/acquia_disable_package_manager/acquia_disable_package_manager.services.yml
+++ b/docroot/modules/custom/acquia_disable_package_manager/acquia_disable_package_manager.services.yml
@@ -1,0 +1,5 @@
+services:
+  Drupal\acquia_disable_package_manager\AhPackageManagerDisabler:
+    tags:
+      - { name: event_subscriber }
+      - { name: config.factory.override }

--- a/docroot/modules/custom/acquia_disable_package_manager/composer.json
+++ b/docroot/modules/custom/acquia_disable_package_manager/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "acquia/acquia_disable_package_manager",
-    "description": "A hidden Drupal module to disable Package Manager operations  on Acquia hosting.",
+    "description": "A hidden Drupal module to disable Package Manager operations on Acquia hosting.",
     "type": "drupal-module",
     "require": {
         "acquia/drupal-environment-detector": "^1.8"

--- a/docroot/modules/custom/acquia_disable_package_manager/composer.json
+++ b/docroot/modules/custom/acquia_disable_package_manager/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "acquia/acquia_disable_package_manager",
-    "description": "A hidden Drupal module to disable Package Manager operations on Acquia hosting.",
+    "description": "A hidden Drupal module to disable Package Manager operations  on Acquia hosting.",
     "type": "drupal-module",
     "require": {
         "acquia/drupal-environment-detector": "^1.8"

--- a/docroot/modules/custom/acquia_disable_package_manager/composer.json
+++ b/docroot/modules/custom/acquia_disable_package_manager/composer.json
@@ -1,0 +1,8 @@
+{
+    "name": "acquia/acquia_disable_package_manager",
+    "description": "A hidden Drupal module to disable Package Manager operations  on Acquia hosting.",
+    "type": "drupal-module",
+    "require": {
+        "acquia/drupal-environment-detector": "^1.8"
+    }
+}

--- a/docroot/modules/custom/acquia_disable_package_manager/src/AcquiaDisablePackageManagerServiceProvider.php
+++ b/docroot/modules/custom/acquia_disable_package_manager/src/AcquiaDisablePackageManagerServiceProvider.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Drupal\acquia_disable_package_manager;
+
+use Acquia\DrupalEnvironmentDetector\AcquiaDrupalEnvironmentDetector;
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\DependencyInjection\ServiceModifierInterface;
+use Drupal\package_manager\PathExcluder\SiteFilesExcluder;
+use Drupal\project_browser\Activator\ModuleActivator;
+use Drupal\project_browser\Activator\RecipeActivator;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Alters container service definitions.
+ */
+final readonly class AcquiaDisablePackageManagerServiceProvider implements ServiceModifierInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alter(ContainerBuilder $container): void {
+    if (AcquiaDrupalEnvironmentDetector::isAhEnv()) {
+      if ($container->hasDefinition(SiteFilesExcluder::class)) {
+        $definition = $container->getDefinition(SiteFilesExcluder::class);
+        // @see package_manager.services.yml
+        $wrappers = $definition->getArgument('$wrappers');
+        assert(is_array($wrappers));
+        // Don't bother excluding private files; they're outside the project root on
+        // Acquia hosting.
+        $wrappers = array_diff($wrappers, ['private']);
+        $definition->setArgument('$wrappers', $wrappers);
+      }
+
+      if ($container->hasDefinition(ModuleActivator::class)) {
+        $container->register('acquia.module_activator', AhActivator::class)
+          ->setDecoratedService(ModuleActivator::class)
+          ->setArguments([
+            new Reference('.inner'),
+          ])
+          ->setPublic(FALSE);
+      }
+
+      if ($container->hasDefinition(RecipeActivator::class)) {
+        $container->getDefinition(RecipeActivator::class)
+          ->clearTag('project_browser.activator');
+
+        $container->register('acquia.recipe_activator', AhActivator::class)
+          ->addTag('project_browser.activator')
+          ->setArguments([
+            new Reference(RecipeActivator::class),
+          ])
+          ->setPublic(FALSE);
+      }
+    }
+  }
+
+}

--- a/docroot/modules/custom/acquia_disable_package_manager/src/AhActivator.php
+++ b/docroot/modules/custom/acquia_disable_package_manager/src/AhActivator.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Drupal\acquia_disable_package_manager;
+
+use Acquia\DrupalEnvironmentDetector\AcquiaDrupalEnvironmentDetector;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\project_browser\Activator\ActivationStatus;
+use Drupal\project_browser\Activator\ActivatorInterface;
+use Drupal\project_browser\Activator\InstructionsInterface;
+use Drupal\project_browser\Activator\TasksInterface;
+use Drupal\project_browser\ProjectBrowser\Project;
+
+final class AhActivator implements InstructionsInterface, TasksInterface {
+
+  use StringTranslationTrait;
+
+  public function __construct(
+    private readonly ActivatorInterface $decorated,
+  ) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getStatus(Project $project): ActivationStatus {
+    return $this->decorated->getStatus($project);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function supports(Project $project): bool {
+    return $this->decorated->supports($project);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function activate(Project $project): ?array {
+    return $this->decorated->activate($project);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getInstructions(Project $project, ?string $source_id = NULL): string {
+    if (AcquiaDrupalEnvironmentDetector::isAhEnv() && $this->getStatus($project) === ActivationStatus::Absent) {
+      return (string) $this->t('Acquia Cloud is write-protected by design. To add modules or recipes to your codebase, use a Cloud IDE. You can open or create a Cloud ID from your subscription.');
+    }
+    elseif ($this->decorated instanceof InstructionsInterface) {
+      return $this->decorated->getInstructions($project, $source_id);
+    }
+    return '';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getTasks(Project $project, ?string $source_id = NULL): array {
+    return $this->decorated instanceof TasksInterface
+      ? $this->decorated->getTasks($project, $source_id)
+      : [];
+  }
+
+
+}

--- a/docroot/modules/custom/acquia_disable_package_manager/src/AhPackageManagerDisabler.php
+++ b/docroot/modules/custom/acquia_disable_package_manager/src/AhPackageManagerDisabler.php
@@ -45,7 +45,7 @@ final class AhPackageManagerDisabler implements ConfigFactoryOverrideInterface, 
   public function disable(SandboxValidationEvent $event): void {
     if (AcquiaDrupalEnvironmentDetector::isAhEnv()) {
       $event->addError([
-        $this->t('Package Manager is disabled on Acquia hosting.'),
+        $this->t('Acquia Cloud is write-protected by design. To add or update modules and recipes in your codebase, use a Cloud IDE. You can open or create a Cloud ID from your subscription.'),
       ]);
       // Stop all further validation.
       $event->stopPropagation();

--- a/docroot/modules/custom/acquia_disable_package_manager/src/AhPackageManagerDisabler.php
+++ b/docroot/modules/custom/acquia_disable_package_manager/src/AhPackageManagerDisabler.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\acquia_disable_package_manager;
+
+use Acquia\DrupalEnvironmentDetector\AcquiaDrupalEnvironmentDetector;
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Config\ConfigFactoryOverrideInterface;
+use Drupal\Core\Config\StorageInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\package_manager\Event\PreCreateEvent;
+use Drupal\package_manager\Event\SandboxValidationEvent;
+use Drupal\package_manager\Event\StatusCheckEvent;
+use Drupal\package_manager\Validator\BaseRequirementsFulfilledValidator;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Disables Project Browser and unattended automatic updates on Acquia hosting.
+ */
+final class AhPackageManagerDisabler implements ConfigFactoryOverrideInterface, EventSubscriberInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    $events = [];
+
+    // If Package Manager is disabled, this class won't exist.
+    if (class_exists(SandboxValidationEvent::class)) {
+      $events[StatusCheckEvent::class] = $events[PreCreateEvent::class] = [
+        'disable',
+        // Run before any other validation.
+        BaseRequirementsFulfilledValidator::PRIORITY + 100,
+      ];
+    }
+    return $events;
+  }
+
+  /**
+   * Warns (or errs) because Package Manager is disabled on Acquia hosting.
+   */
+  public function disable(SandboxValidationEvent $event): void {
+    if (AcquiaDrupalEnvironmentDetector::isAhEnv()) {
+      $event->addError([
+        $this->t('Package Manager is disabled on Acquia hosting.'),
+      ]);
+      // Stop all further validation.
+      $event->stopPropagation();
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function loadOverrides($names): array {
+    $overrides = [];
+
+    if (AcquiaDrupalEnvironmentDetector::isAhEnv()) {
+      if (in_array('project_browser.admin_settings', $names, TRUE)) {
+        $overrides['project_browser.admin_settings']['allow_ui_install'] = FALSE;
+      }
+      if (in_array('automatic_updates.settings', $names, TRUE)) {
+        $overrides['automatic_updates.settings']['unattended']['level'] = 'disable';
+        $overrides['automatic_updates.settings']['allow_core_minor_updates'] = FALSE;
+      }
+    }
+    return $overrides;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheSuffix(): string {
+    return 'acquia';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function createConfigObject($name, $collection = StorageInterface::DEFAULT_COLLECTION): null {
+    return NULL;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheableMetadata($name): CacheableMetadata {
+    return new CacheableMetadata();
+  }
+
+}

--- a/docroot/modules/custom/acquia_disable_package_manager/tests/src/Kernel/ServiceOverridesTest.php
+++ b/docroot/modules/custom/acquia_disable_package_manager/tests/src/Kernel/ServiceOverridesTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Drupal\Tests\acquia_disable_package_manager\Kernel;
+
+use Drupal\acquia_disable_package_manager\AcquiaDisablePackageManagerServiceProvider;
+use Drupal\acquia_disable_package_manager\AhActivator;
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\Extension\Requirement\RequirementSeverity;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\package_manager\Exception\SandboxEventException;
+use Drupal\package_manager\PathExcluder\SiteFilesExcluder;
+use Drupal\package_manager\StatusCheckTrait;
+use Drupal\package_manager\ValidationResult;
+use Drupal\project_browser\ActivationManager;
+use Drupal\project_browser\Activator\ModuleActivator;
+use Drupal\project_browser\Activator\RecipeActivator;
+use Drupal\project_browser\ComposerInstaller\Installer;
+use Drupal\project_browser\ProjectBrowser\Project;
+use Drupal\project_browser\ProjectType;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+
+#[CoversClass(AcquiaDisablePackageManagerServiceProvider::class)]
+#[Group('acquia_disable_package_manager')]
+#[RunTestsInSeparateProcesses]
+class ServiceOverridesTest extends KernelTestBase {
+
+  use StatusCheckTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'update',
+    'user',
+    'package_manager',
+    'automatic_updates',
+    'project_browser',
+    'acquia_disable_package_manager',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    putenv('AH_SITE_ENVIRONMENT=dev');
+    parent::setUp();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function register(ContainerBuilder $container): void {
+    parent::register($container);
+
+    $container->getDefinition(ModuleActivator::class)
+      ->setPublic(TRUE);
+    $container->getDefinition(RecipeActivator::class)
+      ->setPublic(TRUE);
+  }
+
+  /**
+   * Tests that container services are altered as expected.
+   */
+  public function testServiceAlterations(): void {
+    // The module activator is straightforwardly decorated.
+    $this->assertInstanceOf(
+      AhActivator::class,
+      $this->container->get(ModuleActivator::class),
+    );
+    // Project Browser's recipe activator is not decorated, because it's
+    // an event subscriber. But the activation-ey parts of it are delegated
+    // to our decorator.
+    $this->assertInstanceOf(
+      RecipeActivator::class,
+      $this->container->get(RecipeActivator::class),
+    );
+
+    $activation_manager = $this->container->get(ActivationManager::class);
+    assert($activation_manager instanceof ActivationManager);
+    $this->assertInstanceOf(
+      AhActivator::class,
+      $activation_manager->getActivatorForProject(new Project(
+        logo: NULL,
+        isCompatible: TRUE,
+        machineName: 'test_recipe',
+        body: [],
+        title: 'Test Recipe',
+        packageName: 'drupal/test_recipe',
+        type: ProjectType::Recipe,
+      )),
+    );
+
+    $wrappers = $this->container->getDefinition(SiteFilesExcluder::class)
+      ->getArgument(2);
+    $this->assertNotContains('private', $wrappers);
+
+    // If we try to do a status check for installation, we should be stopped in our tracks.
+    $installer = $this->container->get(Installer::class);
+    assert($installer instanceof Installer);
+    $results = $this->runStatusCheck($installer);
+    $this->assertCount(1, $results);
+    $result = $results[0];
+    assert($result instanceof ValidationResult);
+    $this->assertSame(RequirementSeverity::Error->value, $result->severity);
+    $this->assertStringStartsWith('Acquia Cloud is write-protected by design.', (string) $result->messages[0]);
+
+    // If we disregard the status check and try to do an installation anyway,
+    // we should get a harsher "no".
+    $this->expectException(SandboxEventException::class);
+    $this->expectExceptionMessage('Acquia Cloud is write-protected by design.');
+    $installer->create();
+  }
+
+}

--- a/recipes/custom/acquia_trials/recipe.yml
+++ b/recipes/custom/acquia_trials/recipe.yml
@@ -2,8 +2,9 @@ name: Acquia Trials
 type: Acquia
 description: 'Enables Acquia Trials extensions: countdown banner, getting-started checklist, and Cloud Platform promotion block.'
 install:
-  - acquia_trials_countdown
+  - acquia_disable_package_manager
   - acquia_trials_checklist
+  - acquia_trials_countdown
   - acquia_trials_cloud_platform
   - acquia_trials_id
 config:


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Package Manager Composer operations won't work on Acquia Cloud hosting by design - due to the unwritable filesystem. This module disables those operations.
