### PR TITLE
ONR-317 | Fix cloud hook scripts

### DIFF
--- a/hooks/common/post-code-deploy/config-import.sh
+++ b/hooks/common/post-code-deploy/config-import.sh
@@ -4,10 +4,14 @@
 #
 # Run drush config:import in all environments post code deploy.
 
-# Map the script inputs to convenient names.
 site="$1"
 target_env="$2"
 
-repo_root="/var/www/html/$site.$target_env"
+# Use vendor drush if available, otherwise fall back to drush9
+drush='drush9'
+if [ -e /var/www/html/vendor/bin/drush ]; then
+  drush='/var/www/html/vendor/bin/drush'
+fi
 
-$repo_root/vendor/bin/drush config:import --yes
+echo "Importing config for $site.$target_env"
+$drush @$site.$target_env cim -y

--- a/hooks/common/post-code-deploy/config-import.sh
+++ b/hooks/common/post-code-deploy/config-import.sh
@@ -4,14 +4,8 @@
 #
 # Run drush config:import in all environments post code deploy.
 
-site="$1"
-target_env="$2"
-
-# Use vendor drush if available, otherwise fall back to drush9
-drush='drush9'
-if [ -e /var/www/html/vendor/bin/drush ]; then
-  drush='/var/www/html/vendor/bin/drush'
-fi
+site=$1
+target_env=$2
 
 echo "Importing config for $site.$target_env"
-$drush @$site.$target_env cim -y
+./vendor/bin/drush @$site.$target_env config:import -y

--- a/hooks/common/post-code-deploy/config-import.sh
+++ b/hooks/common/post-code-deploy/config-import.sh
@@ -5,8 +5,9 @@
 # Run drush config:import in all environments post code deploy.
 
 # Map the script inputs to convenient names.
-site=$1
-target_env=$2
-drush_alias=$site'.'$target_env
+site="$1"
+target_env="$2"
 
-drush @$drush_alias config:import --yes
+repo_root="/var/www/html/$site.$target_env"
+
+$repo_root/vendor/bin/drush config:import --yes

--- a/hooks/common/post-code-deploy/config-import.sh
+++ b/hooks/common/post-code-deploy/config-import.sh
@@ -8,7 +8,11 @@ site=$1
 target_env=$2
 repo_root="/var/www/html"
 
-echo "Current working directory: $(pwd)"
-echo "Importing config for $site.$target_env"
+# Skip if drush not available (fresh install)
+if [ ! -e /var/www/html/vendor/bin/drush ]; then
+  echo "Drush not available, skipping config import"
+  exit 0
+fi
 
+echo "Importing config for $site.$target_env"
 $repo_root/vendor/bin/drush @$site.$target_env config:import -y

--- a/hooks/common/post-code-deploy/config-import.sh
+++ b/hooks/common/post-code-deploy/config-import.sh
@@ -6,6 +6,9 @@
 
 site=$1
 target_env=$2
+repo_root="/var/www/html"
 
+echo "Current working directory: $(pwd)"
 echo "Importing config for $site.$target_env"
-./vendor/bin/drush @$site.$target_env config:import -y
+
+$repo_root/vendor/bin/drush @$site.$target_env config:import -y

--- a/hooks/common/post-code-update/config-import.sh
+++ b/hooks/common/post-code-update/config-import.sh
@@ -4,10 +4,14 @@
 #
 # Run drush config:import in all environments post code deploy.
 
-# Map the script inputs to convenient names.
 site="$1"
 target_env="$2"
 
-repo_root="/var/www/html/$site.$target_env"
+# Use vendor drush if available, otherwise fall back to drush9
+drush='drush9'
+if [ -e /var/www/html/vendor/bin/drush ]; then
+  drush='/var/www/html/vendor/bin/drush'
+fi
 
-$repo_root/vendor/bin/drush config:import --yes
+echo "Importing config for $site.$target_env"
+$drush @$site.$target_env cim -y

--- a/hooks/common/post-code-update/config-import.sh
+++ b/hooks/common/post-code-update/config-import.sh
@@ -4,14 +4,8 @@
 #
 # Run drush config:import in all environments post code deploy.
 
-site="$1"
-target_env="$2"
-
-# Use vendor drush if available, otherwise fall back to drush9
-drush='drush9'
-if [ -e /var/www/html/vendor/bin/drush ]; then
-  drush='/var/www/html/vendor/bin/drush'
-fi
+site=$1
+target_env=$2
 
 echo "Importing config for $site.$target_env"
-$drush @$site.$target_env cim -y
+./vendor/bin/drush @$site.$target_env config:import -y

--- a/hooks/common/post-code-update/config-import.sh
+++ b/hooks/common/post-code-update/config-import.sh
@@ -8,7 +8,11 @@ site=$1
 target_env=$2
 repo_root="/var/www/html"
 
-echo "Current working directory: $(pwd)"
-echo "Importing config for $site.$target_env"
+# Skip if drush not available (fresh install)
+if [ ! -e $repo_root/vendor/bin/drush ]; then
+  echo "Drush not available, skipping config import"
+  exit 0
+fi
 
+echo "Importing config for $site.$target_env"
 $repo_root/vendor/bin/drush @$site.$target_env config:import -y

--- a/hooks/common/post-code-update/config-import.sh
+++ b/hooks/common/post-code-update/config-import.sh
@@ -5,8 +5,9 @@
 # Run drush config:import in all environments post code deploy.
 
 # Map the script inputs to convenient names.
-site=$1
-target_env=$2
-drush_alias=$site'.'$target_env
+site="$1"
+target_env="$2"
 
-drush @$drush_alias config:import --yes
+repo_root="/var/www/html/$site.$target_env"
+
+$repo_root/vendor/bin/drush config:import --yes

--- a/hooks/common/post-code-update/config-import.sh
+++ b/hooks/common/post-code-update/config-import.sh
@@ -6,6 +6,9 @@
 
 site=$1
 target_env=$2
+repo_root="/var/www/html"
 
+echo "Current working directory: $(pwd)"
 echo "Importing config for $site.$target_env"
-./vendor/bin/drush @$site.$target_env config:import -y
+
+$repo_root/vendor/bin/drush @$site.$target_env config:import -y


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Cloud hooks for database updates and config import should _not_ run if the site is not installed.

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Modify the scripts to detect whether Drupal is installed on only run the config import anmd database updates if so.