### PR TITLE
Only run config import and DB updates if Drush is already installed

### DIFF
--- a/hooks/common/post-code-deploy/config-import.sh
+++ b/hooks/common/post-code-deploy/config-import.sh
@@ -9,4 +9,7 @@ site=$1
 target_env=$2
 drush_alias=$site'.'$target_env
 
-drush @$drush_alias config:import --yes
+if drush @$drush_alias status 2>/dev/null | grep -q "Successful"; then
+  drush @$drush_alias updatedb --yes
+  drush @$drush_alias config:import --yes
+fi

--- a/hooks/common/post-code-update/config-import.sh
+++ b/hooks/common/post-code-update/config-import.sh
@@ -2,11 +2,14 @@
 #
 # Cloud Hook: Import config
 #
-# Run drush config:import in all environments post code deploy.
+# Run drush config:import in all environments post code update.
 
 # Map the script inputs to convenient names.
 site=$1
 target_env=$2
 drush_alias=$site'.'$target_env
 
-drush @$drush_alias config:import --yes
+if drush @$drush_alias status 2>/dev/null | grep -q "Successful"; then
+  drush @$drush_alias updatedb --yes
+  drush @$drush_alias config:import --yes
+fi


### PR DESCRIPTION
**Motivation**
Fixes: ONR-317
In #62 we added Cloud Hooks that are run on every code deploy and code change, regardless of whether Drupal is already installed. Of course, the `config:import` command will fail if Drupal isn't installed.

**Proposed changes**
Check to see if Drupal is already installed by grepping the output of `drush status`. The hooks should also include a database update which was inadvertently left out of #62, so adding that here as well.

Supersedes and Closes: #64 - which was a different attempt a fixing this.
