### PR TITLE
Only run config imports if the config directory contains configuration files

### DIFF
--- a/hooks/common/post-code-deploy/config-import.sh
+++ b/hooks/common/post-code-deploy/config-import.sh
@@ -10,6 +10,13 @@ target_env=$2
 drush_alias=$site'.'$target_env
 
 if drush @$drush_alias status 2>/dev/null | grep -q "Successful"; then
+  # Always run database updates if Drupal is installed.
   drush @$drush_alias updatedb --yes
-  drush @$drush_alias config:import --yes
+
+  config_dir=$(drush @$drush_alias core:status --field=config-sync 2>/dev/null)
+  if [ -n "$config_dir" ] && find "$config_dir" -name "*.yml" -print -quit 2>/dev/null | grep -q .; then
+    # Drush will give a non-zero exit code if you try to import an empty config directory. Only run config imports if
+    # the configured directory contains config files.
+    drush @$drush_alias config:import --yes
+  fi
 fi

--- a/hooks/common/post-code-update/config-import.sh
+++ b/hooks/common/post-code-update/config-import.sh
@@ -10,6 +10,13 @@ target_env=$2
 drush_alias=$site'.'$target_env
 
 if drush @$drush_alias status 2>/dev/null | grep -q "Successful"; then
+  # Always run database updates if Drupal is installed.
   drush @$drush_alias updatedb --yes
-  drush @$drush_alias config:import --yes
+
+  config_dir=$(drush @$drush_alias core:status --field=config-sync 2>/dev/null)
+  if [ -n "$config_dir" ] && find "$config_dir" -name "*.yml" -print -quit 2>/dev/null | grep -q .; then
+    # Drush will give a non-zero exit code if you try to import an empty config directory. Only run config imports if
+    # the configured directory contains config files.
+    drush @$drush_alias config:import --yes
+  fi
 fi


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
The provided dist branch doesn't include configuration. Deploying that will fail since the Cloud Hooks try to run config:import and Drush will return a non-zero exit code if the config directory doesn't actually contain config.

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Check to ensure the that the configured config directory contains <config>.yml file (including subdirectories for things like config split)