### PR TITLE
Work around schema validation errors

### DIFF
--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -82,6 +82,8 @@ jobs:
             --account-name=admin \
             --account-pass=admin \
             --yes
+          
+          ./vendor/bin/drush recipe ../recipes/custom/acquia_trials
 
       - name: Remove values that should be unique.
         run: |

--- a/.github/workflows/build-install.yml
+++ b/.github/workflows/build-install.yml
@@ -101,3 +101,5 @@ jobs:
             echo "Drush finished with hidden errors"
             exit 1
           fi
+          
+          ./vendor/bin/drush recipe ../recipes/custom/acquia_trials

--- a/docroot/modules/custom/acquia_trials_checklist/acquia_trials_checklist.module
+++ b/docroot/modules/custom/acquia_trials_checklist/acquia_trials_checklist.module
@@ -34,7 +34,7 @@ function acquia_trials_checklist_checklistapi_checklist_info(): array {
     $checklist_items[$key] = [
       '#title' => $item['title'],
       '#description' => $item['description'],
-      '#url' => Url::fromUri('internal:' . $item['url']),
+      '#url' => Url::fromUserInput($item['url']),
     ];
   }
 

--- a/docroot/modules/custom/acquia_trials_checklist/src/Plugin/Block/TrialsChecklistBlock.php
+++ b/docroot/modules/custom/acquia_trials_checklist/src/Plugin/Block/TrialsChecklistBlock.php
@@ -20,6 +20,15 @@ class TrialsChecklistBlock extends BlockBase {
   /**
    * {@inheritdoc}
    */
+  public function defaultConfiguration(): array {
+    return [
+      'label_display' => '0',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function build(): array {
     $items_def = acquia_trials_checklist_get_items();
     $state_key = 'checklistapi.progress.acquia_trials_checklist';

--- a/docroot/modules/custom/acquia_trials_cloud_platform/src/Plugin/Block/TrialsCloudPlatformBlock.php
+++ b/docroot/modules/custom/acquia_trials_cloud_platform/src/Plugin/Block/TrialsCloudPlatformBlock.php
@@ -20,6 +20,15 @@ class TrialsCloudPlatformBlock extends BlockBase {
   /**
    * {@inheritdoc}
    */
+  public function defaultConfiguration(): array {
+    return [
+      'label_display' => '0',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function build(): array {
     $features = [
       [


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Added `defaultConfiguration()` returning `['label_display' => '0']` to both `TrialsChecklistBlock` and `TrialsCloudPlatformBlock`. This works around a bug in Canvas 1.5.0 where `BlockComponentDiscovery::checkRequirements()` passes `'label_display' => FALSE` (boolean) instead of `'0'` (string) when validating block plugins, which fails core's schema constraints.

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
This also adds applying the acquia_trials recipe to the Site Template install matrix and dist branch build workflow to expose errors like this in CI

