### PR TITLE
Remove checklist link to recipes page

### DIFF
--- a/docroot/modules/custom/acquia_trials_checklist/checklist_items.yml
+++ b/docroot/modules/custom/acquia_trials_checklist/checklist_items.yml
@@ -8,11 +8,6 @@ add_new_component:
   description: 'Drag and drop a hero banner or CTA block from the component library.'
   url: '/canvas'
 
-install_recipe:
-  title: "Install a 'Recipe'"
-  description: 'Instantly add features like SEO or Events via the Project Browser.'
-  url: '/admin/modules/browse/recipes'
-
 brand_your_site:
   title: 'Brand Your Site'
   description: 'Upload your logo and adjust primary colors in Appearance settings.'


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Some site templates have the Recipe Source enabled for package manager, some do not. This means that the `/admin/modules/browse/recipes` route may or may not exists.

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Remove the checklist item that links to the page.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->
Force enable the recipes page on all site templates by overriding config at the end of site install. But I'm hesitant to start overriding config from site templates as we're not the author or owner of those. Alternatively, we could propose upstream changes to those site templates that don't have it enabled and restrict the list of site templates to those that do.

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->
The "Install a 'Recipe'" checklist item should no longer appear on the dashboard.
