### PR TITLE
Use Drupal.displace() for banner and content positioning

### DIFF
--- a/docroot/modules/custom/acquia_trials_countdown/acquia_trials_countdown.libraries.yml
+++ b/docroot/modules/custom/acquia_trials_countdown/acquia_trials_countdown.libraries.yml
@@ -6,6 +6,8 @@ countdown-banner:
     js/acquia_trials_countdown.js: {}
   dependencies:
     - core/drupalSettings
+    - core/drupal
+    - core/once
     - acquia_trials_countdown/qualified
 qualified:
   header: true

--- a/docroot/modules/custom/acquia_trials_countdown/css/acquia_trials_countdown.css
+++ b/docroot/modules/custom/acquia_trials_countdown/css/acquia_trials_countdown.css
@@ -1,11 +1,26 @@
 /* Trials countdown banner
  * All selectors scoped under #trials-countdown-banner to prevent
  * theme styles from bleeding through.
+ *
+ * The banner is position:fixed at the very top of the viewport. To keep it
+ * from covering page content or the admin chrome, JS publishes the banner's
+ * measured height as --acquia-trials-banner-height on <html>, and the rules
+ * below reserve that space declaratively. Because they are CSS calc() rules,
+ * they re-apply automatically whenever a theme or toolbar re-renders (e.g.
+ * after an AJAX form save), which the previous JS-only approach did not.
  */
+:root {
+  --acquia-trials-banner-height: 0px;
+}
+
 #trials-countdown-banner {
-  position: sticky;
+  position: fixed;
   top: 0;
-  z-index: 10000;
+  left: 0;
+  right: 0;
+  /* Just above the highest known admin chrome (classic toolbar tray: 1250),
+   * but below genuinely modal dialogs so it never traps them. */
+  z-index: 1300;
   width: 100%;
   background-color: #FFF8E1;
   border-bottom: 1px solid #F0E3B5;
@@ -14,6 +29,66 @@
   line-height: 1.4;
   color: #333;
   box-sizing: border-box;
+}
+
+/* Generic content push: works for all front-end themes (desktop content is in
+ * normal flow) and for the classic toolbar's content region. */
+body {
+  padding-top: var(--acquia-trials-banner-height, 0px);
+}
+
+/* Offset fixed admin chrome down by the banner height. Core/Gin anchor these
+ * to the top of the viewport (top:0 / inset-block-start:0) and do not offset
+ * themselves, so we must push them. !important is required because the core
+ * rules carry high specificity; they are not themselves !important, so we win.
+ */
+
+/* Core Navigation (the default admin chrome for Drupal CMS site templates). */
+.top-bar {
+  inset-block-start: var(--acquia-trials-banner-height, 0px) !important;
+}
+
+.admin-toolbar {
+  inset-block-start: var(--acquia-trials-banner-height, 0px) !important;
+  /* Shrink the full-height sidebar so it does not overflow the viewport. */
+  block-size: calc(100vh - var(--acquia-trials-banner-height, 0px)) !important;
+}
+
+.admin-toolbar-overlay {
+  inset-block-start: var(--acquia-trials-banner-height, 0px) !important;
+}
+
+/* Gin admin theme. */
+.gin--navigation-top-bar {
+  inset-block-start: var(--acquia-trials-banner-height, 0px) !important;
+}
+
+.gin--navigation .admin-toolbar {
+  inset-block-start: var(--acquia-trials-banner-height, 0px) !important;
+  height: calc(100vh - var(--acquia-trials-banner-height, 0px)) !important;
+}
+
+/* Gin pushes content with body padding only on narrow viewports. */
+@media (max-width: 60.99em) {
+  body.gin--navigation {
+    padding-block-start: calc(var(--gin-toolbar-y-offset) + var(--acquia-trials-banner-height, 0px)) !important;
+  }
+}
+
+/* Gin sticky form-actions bar / sidebar on edit forms. This is the element
+ * behind the "covered after saving forms" report: it anchors at 54px. */
+body:has(.gin--navigation-top-bar .gin-sticky-form-actions) #gin_sidebar {
+  inset-block-start: calc(54px + var(--acquia-trials-banner-height, 0px)) !important;
+  height: calc(100% - 54px - var(--acquia-trials-banner-height, 0px)) !important;
+}
+
+/* Classic core toolbar (not the default here, but handle it defensively). */
+body.toolbar-fixed .toolbar-oriented .toolbar-bar {
+  top: var(--acquia-trials-banner-height, 0px) !important;
+}
+
+.toolbar-horizontal .toolbar-tray {
+  margin-top: var(--acquia-trials-banner-height, 0px) !important;
 }
 
 #trials-countdown-banner .trials-countdown-inner {

--- a/docroot/modules/custom/acquia_trials_countdown/js/acquia_trials_countdown.js
+++ b/docroot/modules/custom/acquia_trials_countdown/js/acquia_trials_countdown.js
@@ -2,7 +2,7 @@
  * @file
  * Trials countdown banner.
  */
-(function (Drupal, drupalSettings) {
+(function (Drupal, drupalSettings, once) {
   'use strict';
 
   // Initialize Qualified command queue so calls buffer until the SDK loads.
@@ -15,11 +15,8 @@
 
   var endTimestamp = drupalSettings.trialsCountdown.endTimestamp;
   var bannerId = 'trials-countdown-banner';
+  var heightVar = '--acquia-trials-banner-height';
   var intervalId;
-  var adminUISelectors = [
-    '.top-bar.gin--navigation-top-bar',
-    'aside#admin-toolbar'
-  ];
 
   function getTimeLeft() {
     var now = Math.floor(Date.now() / 1000);
@@ -74,7 +71,7 @@
 
     var arrow = document.createElement('span');
     arrow.setAttribute('aria-hidden', 'true');
-    arrow.textContent = ' \u203A';
+    arrow.textContent = ' ›';
     cta.appendChild(arrow);
 
     inner.appendChild(textWrap);
@@ -85,51 +82,66 @@
     return timeLeft;
   }
 
-  function offsetAdminUI() {
+  /**
+   * Publishes the banner's measured height as a CSS custom property on <html>.
+   *
+   * CSS rules keyed off this variable reserve space for the banner (body
+   * padding) and offset the fixed admin chrome. Re-running this is the actual
+   * fix for content being covered after a re-render: the CSS recomputes the
+   * offsets from the up-to-date height regardless of what the theme/toolbar
+   * did during its own re-render.
+   */
+  function writeBannerHeight() {
     var banner = document.getElementById(bannerId);
-    var height = banner && banner.offsetHeight ? banner.offsetHeight : 0;
-    var value = height ? height + 'px' : '';
-    adminUISelectors.forEach(function (selector) {
-      var el = document.querySelector(selector);
-      if (el) {
-        el.style.marginTop = value;
-      }
-    });
+    var visible = banner && banner.style.display !== 'none';
+    var height = visible ? banner.getBoundingClientRect().height : 0;
+    document.documentElement.style.setProperty(heightVar, (height || 0) + 'px');
   }
 
   function updateBanner(timeLeftEl) {
     var seconds = getTimeLeft();
     if (seconds <= 0) {
-      timeLeftEl.parentElement.closest('#' + bannerId) &&
-        (document.getElementById(bannerId).style.display = 'none');
-      offsetAdminUI();
+      var banner = document.getElementById(bannerId);
+      if (banner) {
+        banner.style.display = 'none';
+      }
+      // Collapse the reserved space so the layout reverts cleanly.
+      writeBannerHeight();
       clearInterval(intervalId);
       return;
     }
     timeLeftEl.textContent = formatTimeLeft(seconds);
   }
 
-  // Initialize once the DOM is ready.
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', init);
-  } else {
-    init();
-  }
+  Drupal.behaviors.acquiaTrialsCountdown = {
+    attach: function () {
+      // The banner is a singleton living on <body>; create it (and start the
+      // countdown) exactly once even though attach() runs on every AJAX/
+      // BigPipe response.
+      once('acquia-trials-banner', 'body').forEach(function () {
+        var timeLeftEl = createBanner();
+        updateBanner(timeLeftEl);
+        writeBannerHeight();
 
-  function init() {
-    if (document.getElementById(bannerId)) {
-      return;
+        // Keep the published height accurate as the banner reflows (e.g. text
+        // wrapping at narrow widths) or the viewport changes.
+        if (window.ResizeObserver) {
+          var observer = new ResizeObserver(writeBannerHeight);
+          observer.observe(document.getElementById(bannerId));
+        }
+        window.addEventListener('resize', writeBannerHeight);
+        document.addEventListener('drupalViewportOffsetChange', writeBannerHeight);
+
+        intervalId = setInterval(function () {
+          updateBanner(timeLeftEl);
+        }, 60000);
+      });
+
+      // Re-assert the height on every attach. After a form save the toolbar
+      // re-renders and resets its position; re-publishing the height makes the
+      // CSS offsets re-apply so content is never left under the banner.
+      writeBannerHeight();
     }
-    var timeLeftEl = createBanner();
-    updateBanner(timeLeftEl);
-    offsetAdminUI();
+  };
 
-    // Recalculate offset on resize in case banner height changes.
-    window.addEventListener('resize', offsetAdminUI);
-
-    intervalId = setInterval(function () {
-      updateBanner(timeLeftEl);
-    }, 60000);
-  }
-
-})(Drupal, drupalSettings);
+})(Drupal, drupalSettings, once);


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
In some circumstances, the Trials Countdown banner doesn't properly push the page content down resulting in UI elements being obscured by the banner.

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Use `Drupal.displace()` to handle the displacement which is more standard and consistent instead of a bespoke solution.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->
