### PR TITLE
Use tagged release of Byte

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "composer/installers": "^2.3",
         "cweagans/composer-patches": "^2.0",
         "drupal/archimedes": "^1.0",
-        "drupal/byte": "1.x-dev",
+        "drupal/byte": "^1.0.3",
         "drupal/caresphere": "^1.2",
         "drupal/checklistapi": "^2.1",
         "drupal/config_sync_without_site_uuid": "^1.0@beta",


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
We've been using HEAD of Byte since updating to Drupal 11.4 because, at the time, Byte didn't have a compatible release. The project now has a release (1.0.3) that's compatible with 11.4 so we should use that.

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Change version constraint for Byte
